### PR TITLE
feat(transactions): implement service layer with in-memory storage

### DIFF
--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -7,41 +7,32 @@ import {
   Delete,
   Put,
 } from '@nestjs/common';
+import { TransactionsService } from './transactions.service';
 
 type TransactionDto = {
-  value: number;
-  date: string;
+  amount: number;
+  type: string;
   categoryId: number;
-  createdAt?: Date;
-  updatedAt?: Date;
+  date: string;
 };
 
 @Controller('transactions')
 export class TransactionController {
-  constructor() {}
+  constructor(private readonly transactionsService: TransactionsService) {}
 
   @Get()
   getAllTransactions() {
-    return [];
+    return this.transactionsService.getAllTransactions();
   }
 
   @Get(':id')
   getTransactionById(@Param('id') id: number) {
-    return [
-      {
-        id: id,
-        value: 500.0,
-        date: '2026-01-31',
-        categoryId: 1,
-        createdAt: '2026-01-31',
-        updatedAt: '2026-01-31',
-      },
-    ];
+    return this.transactionsService.getTransactionById(id);
   }
 
   @Post()
   createTransaction(@Body() createTransactionDto: TransactionDto) {
-    return createTransactionDto;
+    return this.transactionsService.createTransaction(createTransactionDto);
   }
 
   @Put(':id')
@@ -49,11 +40,11 @@ export class TransactionController {
     @Param('id') id: number,
     @Body() updateTransactionDto: TransactionDto,
   ) {
-    return updateTransactionDto;
+    return this.transactionsService.updateTransaction(id, updateTransactionDto);
   }
 
   @Delete(':id')
   deleteTransaction(@Param('id') id: number) {
-    return [{ message: `Transaction with id ${id} deleted successfully.` }];
+    return this.transactionsService.deleteTransaction(id);
   }
 }

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TransactionController } from './transactions.controller';
+import { TransactionsService } from './transactions.service';
 
 @Module({
   controllers: [TransactionController],
-  providers: [],
-  exports: [],
+  providers: [TransactionsService],
+  exports: [TransactionsService],
 })
 export class TransactionsModule {}

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TransactionsService {
+  private transactions: {
+    id: number;
+    amount: number;
+    type: string;
+    categoryId: number;
+    date: string;
+  }[] = [];
+
+  getAllTransactions() {
+    return this.transactions;
+  }
+
+  getTransactionById(id: number) {
+    return this.transactions.find((transaction) => transaction.id === id);
+  }
+
+  createTransaction(createTransactionDto: {
+    amount: number;
+    type: string;
+    categoryId: number;
+    date: string;
+  }) {
+    const newTransaction = {
+      id: this.transactions.length + 1,
+      ...createTransactionDto,
+    };
+    this.transactions.push(newTransaction);
+    return newTransaction;
+  }
+
+  updateTransaction(
+    id: number,
+    updateTransactionDto: {
+      amount: number;
+      type: string;
+      categoryId: number;
+      date: string;
+    },
+  ) {
+    const transactionIndex = this.transactions.findIndex(
+      (transaction) => transaction.id === id,
+    );
+    if (transactionIndex > -1) {
+      this.transactions[transactionIndex] = { id, ...updateTransactionDto };
+      return this.transactions[transactionIndex];
+    }
+    return null;
+  }
+
+  deleteTransaction(id: number) {
+    const transactionIndex = this.transactions.findIndex(
+      (transaction) => transaction.id === id,
+    );
+    if (transactionIndex > -1) {
+      const deletedTransaction = this.transactions.splice(transactionIndex, 1);
+      return deletedTransaction[0];
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
- Add TransactionsService with CRUD operations
- Inject TransactionsService into TransactionController
- Update TransactionDto to use 'amount' and 'type' fields instead of 'value'
- Remove 'createdAt' and 'updatedAt' from DTO
- Replace mock data with service method calls in controller
- Export TransactionsService from TransactionsModule
- Use in-memory array for temporary transaction storage