### PR TITLE
feat(budgets): implement core budget business rules

### DIFF
--- a/src/modules/budgets/budget.module.ts
+++ b/src/modules/budgets/budget.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { BudgetController } from './budget.controller';
 import { BudgetService } from './budget.service';
 import { CategoriesModule } from '../categories/categories.module';
+import { TransactionsModule } from '../transactions/transactions.module';
 
 @Module({
-  imports: [CategoriesModule],
+  imports: [CategoriesModule, TransactionsModule],
   controllers: [BudgetController],
   providers: [BudgetService],
   exports: [BudgetService],

--- a/src/modules/budgets/budget.service.ts
+++ b/src/modules/budgets/budget.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 import { CategoriesService } from '../categories/categories.service';
+import { TransactionsService } from '../transactions/transactions.service';
 import { BadRequestException } from '@nestjs/common';
 
 @Injectable()
@@ -15,7 +16,10 @@ export class BudgetService {
     type: string;
   }[] = [];
 
-  constructor(private categoriesService: CategoriesService) {}
+  constructor(
+    private categoriesService: CategoriesService,
+    private transactionsService: TransactionsService,
+  ) {}
 
   getAllBudgets() {
     return this.budgets;
@@ -26,6 +30,9 @@ export class BudgetService {
   }
 
   createBudget(budgetData: CreateBudgetDto) {
+    this.validateBudgetData(budgetData);
+    this.checkDuplicateBudget(budgetData);
+
     const category = this.categoriesService.getCategoryById(
       budgetData.categoryId,
     );
@@ -44,6 +51,14 @@ export class BudgetService {
   }
 
   updateBudget(id: number, budgetData: UpdateBudgetDto) {
+    if (
+      budgetData.month !== undefined ||
+      budgetData.year !== undefined ||
+      budgetData.type !== undefined
+    ) {
+      this.validateBudgetDataPartial(budgetData);
+    }
+
     if (budgetData.categoryId !== undefined) {
       const category = this.categoriesService.getCategoryById(
         budgetData.categoryId,
@@ -60,6 +75,7 @@ export class BudgetService {
         ...this.budgets[budgetIndex],
         ...budgetData,
       };
+      this.checkDuplicateBudget(this.budgets[budgetIndex], id);
       return this.budgets[budgetIndex];
     }
     return null;
@@ -72,5 +88,101 @@ export class BudgetService {
       return deletedBudget[0];
     }
     return null;
+  }
+
+  private validateBudgetData(budgetData: CreateBudgetDto): void {
+    if (budgetData.month < 1 || budgetData.month > 12) {
+      throw new BadRequestException('Month must be between 1 and 12');
+    }
+  }
+
+  private validateBudgetDataPartial(budgetData: UpdateBudgetDto): void {
+    if (
+      budgetData.month !== undefined &&
+      (budgetData.month < 1 || budgetData.month > 12)
+    ) {
+      throw new BadRequestException('Month must be between 1 and 12');
+    }
+  }
+
+  private checkDuplicateBudget(
+    budgetData: CreateBudgetDto,
+    excludeId?: number,
+  ): void {
+    const isDuplicate = this.budgets.some(
+      (budget) =>
+        budget.categoryId === budgetData.categoryId &&
+        budget.type === budgetData.type &&
+        budget.month === budgetData.month &&
+        budget.year === budgetData.year &&
+        budget.id !== excludeId,
+    );
+
+    if (isDuplicate) {
+      throw new BadRequestException(
+        `Budget for category ${budgetData.categoryId}, type ${budgetData.type}, month ${budgetData.month}, and year ${budgetData.year} already exists`,
+      );
+    }
+  }
+
+  getSpentAmount(budgetId: number): number {
+    const budget = this.getBudgetById(budgetId);
+    if (!budget) {
+      return 0;
+    }
+
+    const transactions = this.transactionsService.getAllTransactions();
+    const spent = transactions
+      .filter((transaction) => {
+        // Match category and type
+        if (
+          transaction.categoryId !== budget.categoryId ||
+          transaction.type !== budget.type
+        ) {
+          return false;
+        }
+
+        // Extract month and year from transaction date (ISO format: YYYY-MM-DD)
+        const transactionDate = new Date(transaction.date);
+        const transactionMonth = transactionDate.getMonth() + 1;
+        const transactionYear = transactionDate.getFullYear();
+
+        // Check if transaction is within budget period
+        return (
+          transactionMonth === budget.month && transactionYear === budget.year
+        );
+      })
+      .reduce((sum, transaction) => sum + transaction.amount, 0);
+
+    return spent;
+  }
+
+  getRemainingBudget(budgetId: number): number {
+    const budget = this.getBudgetById(budgetId);
+    if (!budget) {
+      return 0;
+    }
+
+    const spent = this.getSpentAmount(budgetId);
+    return budget.amount - spent;
+  }
+
+  getBudgetWithSpending(budgetId: number): any {
+    const budget = this.getBudgetById(budgetId);
+    if (!budget) {
+      return null;
+    }
+
+    const spent = this.getSpentAmount(budgetId);
+    const remaining = this.getRemainingBudget(budgetId);
+    const utilizationPercentage =
+      budget.amount > 0 ? (spent / budget.amount) * 100 : 0;
+
+    return {
+      ...budget,
+      spent,
+      remaining,
+      utilizationPercentage,
+    };
   }
 }


### PR DESCRIPTION
- Add TransactionsModule import to BudgetModule for spending tracking
- Inject TransactionsService into BudgetService
- Add validateBudgetData() to ensure month is between 1-12
- Add validateBudgetDataPartial() for update validation
- Add checkDuplicateBudget() to prevent duplicate budgets for same category/type/month/year
- Add getSpentAmount(budgetId) to calculate total spending by filtering transactions matching budget's categoryId, type, and month/year period
- Add getRemainingBudget(budgetId) to return amount minus spent (allows negative for overspending)
- Add getBudgetWithSpending(budgetId) to return enriched budget with spent, remaining, and utilizationPercentage fields
- Integrate validation into createBudget() and updateBudget() methods

Acceptance criteria met:
✓ Budget rules encapsulated in service (no controller logic) ✓ Spending vs limit tracking for category + type combinations ✓ Remaining budget calculation with support for negative balances ✓ Ready for integration with transactions