### PR TITLE
feat(budgets): associate budgets with categories and transactions

### DIFF
--- a/src/modules/budgets/budget.controller.ts
+++ b/src/modules/budgets/budget.controller.ts
@@ -25,6 +25,16 @@ export class BudgetController {
     return this.budgetService.getBudgetById(+id);
   }
 
+  @Get(':id/details')
+  getBudgetsWithTransactions(@Param('id') id: string) {
+    return this.budgetService.getBudgetsWithTransactions(+id);
+  }
+
+  @Get('category/:categoryId')
+  getBudgetsByCategory(@Param('categoryId') categoryId: string) {
+    return this.budgetService.getBudgetsByCategory(+categoryId);
+  }
+
   @Post()
   createBudget(@Body() budgetData: CreateBudgetDto) {
     return this.budgetService.createBudget(budgetData);


### PR DESCRIPTION
- Add getTransactionsForBudget(budgetId) helper method to filter and return transactions matching budget's categoryId, type, and month/year period
- Add getBudgetWithCategory(budgetId) to enrich budget with full category object {id, name, type}
- Add getBudgetsWithTransactions(budgetId) to return complete budget detail with category, matching transactions, and aggregated spending data (spent, remaining, utilizationPercentage)
- Add getBudgetsByCategory(categoryId) query method to return all budgets for a category with spending details calculated for each
- Add GET /budgets/:id/details endpoint to retrieve budget with category and transactions
- Add GET /budgets/category/:categoryId endpoint to retrieve all budgets for a category with spending

This enables:
✓ Budget references category (full object with id, name, type) ✓ Transaction data aggregated and associated with budgets ✓ Structure supports future reports (spending aggregation ready) ✓ Graceful empty array returns (no errors on missing data)