### PR TITLE
feat: define Prisma schema for Category entity with INCOME/EXPENSE types

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,4 +10,29 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// Models will be added in future migrations
+enum CategoryType {
+  INCOME
+  EXPENSE
+}
+
+model Category {
+  id           String   @id @default(uuid()) @db.Uuid
+  name         String
+  type         CategoryType
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  transactions Transaction[]
+  budgets      Budget[]
+}
+
+model Transaction {
+  id         String   @id @default(uuid()) @db.Uuid
+  categoryId String   @db.Uuid
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+}
+
+model Budget {
+  id           String   @id @default(uuid()) @db.Uuid
+  categoryId   String   @db.Uuid
+  category     Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+}


### PR DESCRIPTION
- Add CategoryType enum with INCOME and EXPENSE values
- Create Category model with id, name, type, createdAt, updatedAt fields
- Establish one-to-many relations with Transaction and Budget models
- Add required categoryId foreign keys to Transaction and Budget
- Configure cascade delete behavior for category relationships
- Schema validates successfully and is ready for migration