### PR TITLE
feat: define Prisma schema for Transaction entity with financial fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,11 @@ enum CategoryType {
   EXPENSE
 }
 
+enum TransactionType {
+  INCOME
+  EXPENSE
+}
+
 model Category {
   id           String   @id @default(uuid()) @db.Uuid
   name         String
@@ -26,9 +31,15 @@ model Category {
 }
 
 model Transaction {
-  id         String   @id @default(uuid()) @db.Uuid
-  categoryId String   @db.Uuid
-  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  id          String          @id @default(uuid()) @db.Uuid
+  amount      Decimal         @db.Decimal(10, 2)
+  description String?
+  date        DateTime
+  type        TransactionType
+  categoryId  String          @db.Uuid
+  category    Category        @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
 }
 
 model Budget {


### PR DESCRIPTION
- Add TransactionType enum with INCOME and EXPENSE values aligned with CategoryType
- Add amount field with Decimal(10, 2) precision for accurate financial calculations
- Add optional description field for transaction details
- Add required date field for transaction timestamp
- Add type field using TransactionType enum
- Add createdAt and updatedAt timestamp fields
- Maintain required categoryId foreign key with cascade delete relation
- Schema validates successfully and is ready for migration