### PR TITLE
feat(prisma): define Budget schema with category-based aggregation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,11 @@ enum TransactionType {
   EXPENSE
 }
 
+enum BudgetType {
+  EXPENSE
+  SAVINGS
+}
+
 model Category {
   id           String   @id @default(uuid()) @db.Uuid
   name         String
@@ -43,7 +48,15 @@ model Transaction {
 }
 
 model Budget {
-  id           String   @id @default(uuid()) @db.Uuid
-  categoryId   String   @db.Uuid
-  category     Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  id           String     @id @default(uuid()) @db.Uuid
+  amount       Decimal    @db.Decimal(10, 2)
+  month        Int
+  year         Int
+  type         BudgetType
+  categoryId   String     @db.Uuid
+  category     Category   @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  @@unique([categoryId, month, year, type])
 }


### PR DESCRIPTION
- Add BudgetType enum (EXPENSE, SAVINGS) for budget categorization
- Expand Budget model with required fields:
  * amount (Decimal 10,2) for budget value
  * month (Int 1-12) and year (Int) for time period
  * type (BudgetType) for budget classification
  * createdAt and updatedAt timestamps
- Add composite unique constraint on (categoryId, month, year, type)
- Maintain many-to-one relation with Category (CASCADE delete)
- Enable logical aggregation of transactions by budget