### PR TITLE
feat: create PrismaService and SharedModule for database integration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,16 @@ import { HealthModule } from './modules/health/health.module';
 import { CategoriesModule } from './modules/categories/categories.module';
 import { TransactionsModule } from './modules/transactions/transactions.module';
 import { BudgetModule } from './modules/budgets/budget.module';
+import { SharedModule } from './modules/shared';
 
 @Module({
-  imports: [HealthModule, CategoriesModule, TransactionsModule, BudgetModule],
+  imports: [
+    SharedModule,
+    HealthModule,
+    CategoriesModule,
+    TransactionsModule,
+    BudgetModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/modules/shared/index.ts
+++ b/src/modules/shared/index.ts
@@ -1,0 +1,2 @@
+export { PrismaService } from './prisma.service';
+export { SharedModule } from './shared.module';

--- a/src/modules/shared/prisma.service.ts
+++ b/src/modules/shared/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class SharedModule {}


### PR DESCRIPTION
- Create PrismaService extending PrismaClient with @Injectable() decorator
- Implement onModuleInit() to connect to database on module initialization
- Implement onModuleDestroy() to gracefully disconnect on application shutdown
- Create SharedModule as module-level provider for PrismaService singleton
- Create barrel export (index.ts) for clean imports from shared module
- Import SharedModule first in AppModule to ensure PrismaService availability to all feature modules