### PR TITLE
feat(categories): use Prisma for CRUD with UUIDs and ordered listing

### DIFF
--- a/src/modules/budgets/budget.controller.ts
+++ b/src/modules/budgets/budget.controller.ts
@@ -31,8 +31,10 @@ export class BudgetController {
   }
 
   @Get('category/:categoryId')
-  getBudgetsByCategory(@Param('categoryId') categoryId: string) {
-    return this.budgetService.getBudgetsByCategory(+categoryId);
+  getBudgetsByCategory(
+    @Param('categoryId') categoryId: string,
+  ): ReturnType<BudgetService['getBudgetsByCategory']> {
+    return this.budgetService.getBudgetsByCategory(categoryId);
   }
 
   @Post()

--- a/src/modules/budgets/dto/create-budget.dto.ts
+++ b/src/modules/budgets/dto/create-budget.dto.ts
@@ -3,8 +3,8 @@ import { IsNumber, IsString } from 'class-validator';
 export class CreateBudgetDto {
   @IsNumber()
   amount: number;
-  @IsNumber()
-  categoryId: number;
+  @IsString()
+  categoryId: string;
   @IsNumber()
   month: number;
   @IsNumber()

--- a/src/modules/budgets/dto/update-budget.dto.ts
+++ b/src/modules/budgets/dto/update-budget.dto.ts
@@ -3,8 +3,8 @@ import { IsNumber, IsString } from 'class-validator';
 export class UpdateBudgetDto {
   @IsNumber()
   amount?: number;
-  @IsNumber()
-  categoryId?: number;
+  @IsString()
+  categoryId?: string;
   @IsNumber()
   month?: number;
   @IsNumber()

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -21,7 +21,7 @@ export class CategoriesController {
   }
 
   @Get(':id')
-  getCategoryById(@Param('id') id: number) {
+  getCategoryById(@Param('id') id: string) {
     return this.categoriesService.getCategoryById(id);
   }
 
@@ -32,14 +32,14 @@ export class CategoriesController {
 
   @Put(':id')
   updateCategory(
-    @Param('id') id: number,
+    @Param('id') id: string,
     @Body() updateCategoryDto: UpdateCategoryDto,
   ) {
     return this.categoriesService.updateCategory(id, updateCategoryDto);
   }
 
   @Delete(':id')
-  deleteCategory(@Param('id') id: number) {
+  deleteCategory(@Param('id') id: string) {
     return this.categoriesService.deleteCategory(id);
   }
 }

--- a/src/modules/categories/categories.module.ts
+++ b/src/modules/categories/categories.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CategoriesController } from './categories.controller';
+import { SharedModule } from '../shared/shared.module';
 
 @Module({
+  imports: [SharedModule],
   controllers: [CategoriesController],
   providers: [CategoriesService],
   exports: [CategoriesService],

--- a/src/modules/categories/categories.service.spec.ts
+++ b/src/modules/categories/categories.service.spec.ts
@@ -1,59 +1,188 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesService } from './categories.service';
+import { PrismaService } from '../shared/prisma.service';
+import { NotFoundException } from '@nestjs/common';
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
+  let prismaService: PrismaService;
+
+  const prismaMock = {
+    category: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  } as unknown as PrismaService;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoriesService],
+      providers: [
+        CategoriesService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);
+    prismaService = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
-  it('should create a category', () => {
-    const category = service.createCategory({
+  it('should create a category', async () => {
+    const categoryResponse = {
+      id: '1a2b3c4d-0000-0000-0000-000000000000',
+      name: 'PayCheck',
+      type: 'INCOME',
+      createdAt: new Date('2026-02-13T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+    };
+
+    jest
+      .spyOn(prismaService.category, 'create')
+      .mockResolvedValue(categoryResponse);
+
+    const category = await service.createCategory({
       name: 'PayCheck',
       type: 'income',
     });
-    expect(category).toEqual({ id: 1, name: 'PayCheck', type: 'income' });
+    expect(category).toEqual({
+      ...categoryResponse,
+      type: 'income',
+    });
   });
 
-  it('should get all categories', () => {
-    service.createCategory({ name: 'PayCheck', type: 'income' });
-    const categories = service.getAllCategories();
-    expect(categories.length).toBe(1);
+  it('should get all categories ordered by name', async () => {
+    const categoriesResponse = [
+      {
+        id: 'a',
+        name: 'Alpha',
+        type: 'INCOME',
+        createdAt: new Date('2026-02-13T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+      },
+      {
+        id: 'b',
+        name: 'Zeta',
+        type: 'EXPENSE',
+        createdAt: new Date('2026-02-13T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+      },
+    ];
+
+    jest
+      .spyOn(prismaService.category, 'findMany')
+      .mockResolvedValue(categoriesResponse);
+
+    const categories = await service.getAllCategories();
+    expect(prismaService.category.findMany).toHaveBeenCalledWith({
+      orderBy: { name: 'asc' },
+    });
+    expect(categories).toEqual([
+      {
+        ...categoriesResponse[0],
+        type: 'income',
+      },
+      {
+        ...categoriesResponse[1],
+        type: 'expense',
+      },
+    ]);
   });
 
-  it('should get category by id', () => {
-    service.createCategory({ name: 'PayCheck', type: 'income' });
-    const category = service.getCategoryById(1);
-    expect(category).toEqual({ id: 1, name: 'PayCheck', type: 'income' });
+  it('should get category by id', async () => {
+    const categoryResponse = {
+      id: '1a2b3c4d-0000-0000-0000-000000000000',
+      name: 'PayCheck',
+      type: 'INCOME',
+      createdAt: new Date('2026-02-13T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+    };
+
+    jest
+      .spyOn(prismaService.category, 'findUnique')
+      .mockResolvedValue(categoryResponse);
+
+    const category = await service.getCategoryById(
+      '1a2b3c4d-0000-0000-0000-000000000000',
+    );
+
+    expect(category).toEqual({
+      ...categoryResponse,
+      type: 'income',
+    });
   });
 
-  it('should update a category', () => {
-    service.createCategory({ name: 'PayCheck', type: 'income' });
-    const updatedCategory = service.updateCategory(1, {
+  it('should throw when category is missing', async () => {
+    jest.spyOn(prismaService.category, 'findUnique').mockResolvedValue(null);
+
+    await expect(service.getCategoryById('missing-id')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('should update a category partially', async () => {
+    const existingCategory = {
+      id: '1a2b3c4d-0000-0000-0000-000000000000',
+      name: 'PayCheck',
+      type: 'INCOME',
+      createdAt: new Date('2026-02-13T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+    };
+
+    const updatedCategory = {
+      ...existingCategory,
       name: 'Salary',
+    };
+
+    jest
+      .spyOn(prismaService.category, 'findUnique')
+      .mockResolvedValue(existingCategory);
+    jest
+      .spyOn(prismaService.category, 'update')
+      .mockResolvedValue(updatedCategory);
+
+    const result = await service.updateCategory(
+      '1a2b3c4d-0000-0000-0000-000000000000',
+      { name: 'Salary' },
+    );
+
+    expect(result).toEqual({
+      ...updatedCategory,
       type: 'income',
     });
-    expect(updatedCategory).toEqual({ id: 1, name: 'Salary', type: 'income' });
   });
 
-  it('should delete a category', () => {
-    service.createCategory({ name: 'PayCheck', type: 'income' });
-    const deletedCategory = service.deleteCategory(1);
-    expect(deletedCategory).toEqual({
-      id: 1,
+  it('should delete a category', async () => {
+    const deletedCategory = {
+      id: '1a2b3c4d-0000-0000-0000-000000000000',
       name: 'PayCheck',
+      type: 'INCOME',
+      createdAt: new Date('2026-02-13T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-13T00:00:00.000Z'),
+    };
+
+    jest
+      .spyOn(prismaService.category, 'findUnique')
+      .mockResolvedValue({ id: deletedCategory.id } as any);
+    jest
+      .spyOn(prismaService.category, 'delete')
+      .mockResolvedValue(deletedCategory);
+
+    const result = await service.deleteCategory(deletedCategory.id);
+
+    expect(result).toEqual({
+      ...deletedCategory,
       type: 'income',
     });
-    const categories = service.getAllCategories();
-    expect(categories.length).toBe(0);
   });
 });

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,10 +1,13 @@
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateCategoryDto {
   //   @IsNumber()
   //   id: number;
+  @IsOptional()
   @IsString()
-  name: string;
+  name?: string;
+
+  @IsOptional()
   @IsString()
-  type: string;
+  type?: string;
 }

--- a/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/src/modules/transactions/dto/create-transaction.dto.ts
@@ -7,8 +7,8 @@ export class CreateTransactionDto {
   @IsString()
   type: string;
 
-  @IsNumber()
-  categoryId: number;
+  @IsString()
+  categoryId: string;
 
   @IsString()
   date: string;

--- a/src/modules/transactions/dto/update-transaction.dto.ts
+++ b/src/modules/transactions/dto/update-transaction.dto.ts
@@ -13,8 +13,8 @@ export class UpdateTransactionDto {
   type?: string;
 
   @IsOptional()
-  @IsNumber()
-  categoryId?: number;
+  @IsString()
+  categoryId?: string;
 
   @IsOptional()
   @IsString()

--- a/src/modules/transactions/transactions.service.spec.ts
+++ b/src/modules/transactions/transactions.service.spec.ts
@@ -8,6 +8,8 @@ import { UpdateTransactionDto } from './dto/update-transaction.dto';
 describe('TransactionsService', () => {
   let service: TransactionsService;
   let categoriesService: CategoriesService;
+  const categoryId = '11111111-1111-1111-1111-111111111111';
+  const otherCategoryId = '22222222-2222-2222-2222-222222222222';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -36,9 +38,9 @@ describe('TransactionsService', () => {
       expect(transactions).toEqual([]);
     });
 
-    it('should return all transactions after creating some', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should return all transactions after creating some', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -46,13 +48,13 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
+      await service.createTransaction(createDto);
 
       const transactions = service.getAllTransactions();
       expect(transactions.length).toBe(2);
@@ -65,9 +67,9 @@ describe('TransactionsService', () => {
       expect(transaction).toBeUndefined();
     });
 
-    it('should return the transaction if it exists', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should return the transaction if it exists', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -75,12 +77,12 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
       const transaction = service.getTransactionById(1);
 
       expect(transaction).toBeDefined();
@@ -91,9 +93,9 @@ describe('TransactionsService', () => {
   });
 
   describe('createTransaction', () => {
-    it('should create a transaction with valid category', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should create a transaction with valid category', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -101,25 +103,25 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      const transaction = service.createTransaction(createDto);
+      const transaction = await service.createTransaction(createDto);
 
       expect(transaction).toBeDefined();
       expect(transaction.id).toBe(1);
       expect(transaction.amount).toBe(1000);
       expect(transaction.type).toBe('income');
-      expect(transaction.categoryId).toBe(1);
+      expect(transaction.categoryId).toBe(categoryId);
       expect(transaction.date).toBe('2025-01-01');
       expect(transaction.description).toBe('Monthly salary');
     });
 
-    it('should auto-increment transaction IDs', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should auto-increment transaction IDs', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -127,40 +129,40 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      const transaction1 = service.createTransaction(createDto);
-      const transaction2 = service.createTransaction(createDto);
+      const transaction1 = await service.createTransaction(createDto);
+      const transaction2 = await service.createTransaction(createDto);
 
       expect(transaction1.id).toBe(1);
       expect(transaction2.id).toBe(2);
     });
 
-    it('should throw BadRequestException if category does not exist', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue(null);
+    it('should throw BadRequestException if category does not exist', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue(null);
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 999,
+        categoryId: otherCategoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      expect(() => service.createTransaction(createDto)).toThrow(
+      await expect(service.createTransaction(createDto)).rejects.toThrow(
         BadRequestException,
       );
-      expect(() => service.createTransaction(createDto)).toThrow(
-        `Category with ID 999 does not exist`,
+      await expect(service.createTransaction(createDto)).rejects.toThrow(
+        `Category with ID ${otherCategoryId} does not exist`,
       );
     });
 
-    it('should persist transaction in memory', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should persist transaction in memory', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -168,12 +170,12 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
       const allTransactions = service.getAllTransactions();
 
       expect(allTransactions.length).toBe(1);
@@ -182,9 +184,9 @@ describe('TransactionsService', () => {
   });
 
   describe('updateTransaction', () => {
-    beforeEach(() => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    beforeEach(async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -192,44 +194,44 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
     });
 
-    it('should return null if transaction does not exist', () => {
+    it('should return null if transaction does not exist', async () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
       };
 
-      const result = service.updateTransaction(999, updateDto);
+      const result = await service.updateTransaction(999, updateDto);
       expect(result).toBeNull();
     });
 
-    it('should update amount field', () => {
+    it('should update amount field', async () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
       };
 
-      const updated = service.updateTransaction(1, updateDto);
+      const updated = await service.updateTransaction(1, updateDto);
 
       expect(updated).toBeDefined();
       expect(updated.amount).toBe(2000);
       expect(updated.description).toBe('Monthly salary');
-      expect(updated.categoryId).toBe(1);
+      expect(updated.categoryId).toBe(categoryId);
     });
 
-    it('should update multiple fields', () => {
+    it('should update multiple fields', async () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
         description: 'Bonus payment',
         type: 'bonus',
       };
 
-      const updated = service.updateTransaction(1, updateDto);
+      const updated = await service.updateTransaction(1, updateDto);
 
       expect(updated.amount).toBe(2000);
       expect(updated.description).toBe('Bonus payment');
@@ -237,54 +239,54 @@ describe('TransactionsService', () => {
       expect(updated.date).toBe('2025-01-01');
     });
 
-    it('should validate category when updating categoryId', () => {
+    it('should validate category when updating categoryId', async () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
 
       // Mock the method to return null for invalid category
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue(null);
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue(null);
 
       const updateDto: UpdateTransactionDto = {
-        categoryId: 999,
+        categoryId: otherCategoryId,
       };
 
-      expect(() => service.updateTransaction(1, updateDto)).toThrow(
+      await expect(service.updateTransaction(1, updateDto)).rejects.toThrow(
         BadRequestException,
       );
-      expect(() => service.updateTransaction(1, updateDto)).toThrow(
-        `Category with ID 999 does not exist`,
+      await expect(service.updateTransaction(1, updateDto)).rejects.toThrow(
+        `Category with ID ${otherCategoryId} does not exist`,
       );
     });
 
-    it('should not validate category if categoryId is not being updated', () => {
+    it('should not validate category if categoryId is not being updated', async () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
       };
 
-      const updated = service.updateTransaction(1, updateDto);
+      const updated = await service.updateTransaction(1, updateDto);
 
       expect(updated).toBeDefined();
       expect(updated.amount).toBe(2000);
       expect(categoriesService.getCategoryById).toHaveBeenCalledTimes(1); // Only called during create
     });
 
-    it('should update category if new category exists', () => {
+    it('should update category if new category exists', async () => {
       jest
         .spyOn(categoriesService, 'getCategoryById')
-        .mockReturnValueOnce({
-          id: 1,
+        .mockResolvedValueOnce({
+          id: categoryId,
           name: 'Salary',
           type: 'income',
         } as any)
-        .mockReturnValueOnce({
-          id: 2,
+        .mockResolvedValueOnce({
+          id: otherCategoryId,
           name: 'Bonus',
           type: 'income',
         } as any);
@@ -292,27 +294,27 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
 
       const updateDto: UpdateTransactionDto = {
-        categoryId: 2,
+        categoryId: otherCategoryId,
       };
 
-      const updated = service.updateTransaction(1, updateDto);
+      const updated = await service.updateTransaction(1, updateDto);
 
-      expect(updated.categoryId).toBe(2);
+      expect(updated.categoryId).toBe(otherCategoryId);
     });
   });
 
   describe('deleteTransaction', () => {
-    beforeEach(() => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    beforeEach(async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -320,12 +322,12 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
     });
 
     it('should return null if transaction does not exist', () => {
@@ -348,9 +350,9 @@ describe('TransactionsService', () => {
       expect(remaining.length).toBe(0);
     });
 
-    it('should remove only the specified transaction', () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockReturnValue({
-        id: 1,
+    it('should remove only the specified transaction', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        id: categoryId,
         name: 'Salary',
         type: 'income',
       } as any);
@@ -358,12 +360,12 @@ describe('TransactionsService', () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
         type: 'income',
-        categoryId: 1,
+        categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
       };
 
-      service.createTransaction(createDto);
+      await service.createTransaction(createDto);
 
       service.deleteTransaction(1);
       const remaining = service.getAllTransactions();


### PR DESCRIPTION
Replace in-memory category storage with Prisma queries Throw on missing categories and allow partial updates Adjust controllers/DTOs for string category IDs
Update budgets/transactions to async category validation Refresh unit tests with Prisma mocks and ordering assertions