### PR TITLE
refactor(transactions): switch to Prisma CRUD with UUIDs and normaliz…

### DIFF
--- a/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/src/modules/transactions/dto/create-transaction.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsString } from 'class-validator';
+import { IsDateString, IsNumber, IsString, IsUUID } from 'class-validator';
 
 export class CreateTransactionDto {
   @IsNumber()
@@ -7,10 +7,10 @@ export class CreateTransactionDto {
   @IsString()
   type: string;
 
-  @IsString()
+  @IsUUID()
   categoryId: string;
 
-  @IsString()
+  @IsDateString()
   date: string;
 
   @IsString()

--- a/src/modules/transactions/dto/update-transaction.dto.ts
+++ b/src/modules/transactions/dto/update-transaction.dto.ts
@@ -1,9 +1,12 @@
-import { IsNumber, IsString, IsOptional } from 'class-validator';
+import {
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 
 export class UpdateTransactionDto {
-  @IsOptional()
-  @IsNumber()
-  id?: number;
   @IsOptional()
   @IsNumber()
   amount?: number;
@@ -13,11 +16,11 @@ export class UpdateTransactionDto {
   type?: string;
 
   @IsOptional()
-  @IsString()
+  @IsUUID()
   categoryId?: string;
 
   @IsOptional()
-  @IsString()
+  @IsDateString()
   date?: string;
 
   @IsOptional()

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Delete,
   Put,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { TransactionsService } from './transactions.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
@@ -15,30 +16,30 @@ export class TransactionController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
   @Get()
-  getAllTransactions() {
+  async getAllTransactions() {
     return this.transactionsService.getAllTransactions();
   }
 
   @Get(':id')
-  getTransactionById(@Param('id') id: number) {
+  async getTransactionById(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.transactionsService.getTransactionById(id);
   }
 
   @Post()
-  createTransaction(@Body() createTransactionDto: CreateTransactionDto) {
+  async createTransaction(@Body() createTransactionDto: CreateTransactionDto) {
     return this.transactionsService.createTransaction(createTransactionDto);
   }
 
   @Put(':id')
-  updateTransaction(
-    @Param('id') id: number,
+  async updateTransaction(
+    @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateTransactionDto: UpdateTransactionDto,
   ) {
     return this.transactionsService.updateTransaction(id, updateTransactionDto);
   }
 
   @Delete(':id')
-  deleteTransaction(@Param('id') id: number) {
+  async deleteTransaction(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.transactionsService.deleteTransaction(id);
   }
 }

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TransactionController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
 import { CategoriesModule } from '../categories/categories.module';
+import { SharedModule } from '../shared/shared.module';
 
 @Module({
-  imports: [CategoriesModule],
+  imports: [CategoriesModule, SharedModule],
   controllers: [TransactionController],
   providers: [TransactionsService],
   exports: [TransactionsService],

--- a/src/modules/transactions/transactions.service.spec.ts
+++ b/src/modules/transactions/transactions.service.spec.ts
@@ -1,17 +1,96 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TransactionType } from '@prisma/client';
 import { TransactionsService } from './transactions.service';
 import { CategoriesService } from '../categories/categories.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { PrismaService } from '../shared/prisma.service';
+
+type TransactionRecord = {
+  id: string;
+  amount: number;
+  type: TransactionType;
+  categoryId: string;
+  date: Date;
+  description: string | null;
+};
+
+const stripUndefined = <T extends Record<string, any>>(value: T) =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+  );
+
+const createPrismaMock = () => {
+  let store: TransactionRecord[] = [];
+  let idIndex = 0;
+  const ids = [
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    'cccccccc-cccc-cccc-cccc-cccccccccccc',
+  ];
+
+  return {
+    transaction: {
+      findMany: jest.fn(() => store),
+      findUnique: jest.fn(
+        ({ where: { id } }) =>
+          store.find((transaction) => transaction.id === id) ?? null,
+      ),
+      create: jest.fn(({ data }) => {
+        const cleanedData = stripUndefined(data) as Omit<
+          TransactionRecord,
+          'id'
+        >;
+        const transaction = {
+          id: ids[idIndex++] ?? 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+          ...cleanedData,
+          description: cleanedData.description ?? null,
+        } as TransactionRecord;
+        store.push(transaction);
+        return transaction;
+      }),
+      update: jest.fn(({ where: { id }, data }) => {
+        const index = store.findIndex((transaction) => transaction.id === id);
+        const cleanedData = stripUndefined(data) as Partial<TransactionRecord>;
+        const updated = {
+          ...store[index],
+          ...cleanedData,
+        } as TransactionRecord;
+        store[index] = updated;
+        return updated;
+      }),
+      delete: jest.fn(({ where: { id } }) => {
+        const index = store.findIndex((transaction) => transaction.id === id);
+        const [removed] = store.splice(index, 1);
+        return removed;
+      }),
+    },
+    __reset: () => {
+      store = [];
+      idIndex = 0;
+    },
+  };
+};
+
+const buildCategory = (id: string, name: string) => ({
+  id,
+  name,
+  type: 'income',
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+});
 
 describe('TransactionsService', () => {
   let service: TransactionsService;
   let categoriesService: CategoriesService;
   const categoryId = '11111111-1111-1111-1111-111111111111';
   const otherCategoryId = '22222222-2222-2222-2222-222222222222';
+  const missingTransactionId = '33333333-3333-3333-3333-333333333333';
+  let prismaMock: ReturnType<typeof createPrismaMock>;
 
   beforeEach(async () => {
+    prismaMock = createPrismaMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionsService,
@@ -21,11 +100,16 @@ describe('TransactionsService', () => {
             getCategoryById: jest.fn(),
           },
         },
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
       ],
     }).compile();
 
     service = module.get<TransactionsService>(TransactionsService);
     categoriesService = module.get<CategoriesService>(CategoriesService);
+    prismaMock.__reset();
   });
 
   it('should be defined', () => {
@@ -33,17 +117,15 @@ describe('TransactionsService', () => {
   });
 
   describe('getAllTransactions', () => {
-    it('should return an empty array initially', () => {
-      const transactions = service.getAllTransactions();
+    it('should return an empty array initially', async () => {
+      const transactions = await service.getAllTransactions();
       expect(transactions).toEqual([]);
     });
 
     it('should return all transactions after creating some', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -56,23 +138,22 @@ describe('TransactionsService', () => {
       await service.createTransaction(createDto);
       await service.createTransaction(createDto);
 
-      const transactions = service.getAllTransactions();
+      const transactions = await service.getAllTransactions();
       expect(transactions.length).toBe(2);
     });
   });
 
   describe('getTransactionById', () => {
-    it('should return undefined for non-existent transaction', () => {
-      const transaction = service.getTransactionById(999);
+    it('should return undefined for non-existent transaction', async () => {
+      const transaction =
+        await service.getTransactionById(missingTransactionId);
       expect(transaction).toBeUndefined();
     });
 
     it('should return the transaction if it exists', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -82,11 +163,14 @@ describe('TransactionsService', () => {
         description: 'Monthly salary',
       };
 
-      await service.createTransaction(createDto);
-      const transaction = service.getTransactionById(1);
+      const created = await service.createTransaction(createDto);
+      const transaction = await service.getTransactionById(created.id);
 
       expect(transaction).toBeDefined();
-      expect(transaction.id).toBe(1);
+      if (!transaction) {
+        throw new Error('Expected transaction to be defined');
+      }
+      expect(transaction?.id).toBe(created.id);
       expect(transaction.amount).toBe(1000);
       expect(transaction.description).toBe('Monthly salary');
     });
@@ -95,10 +179,8 @@ describe('TransactionsService', () => {
   describe('createTransaction', () => {
     it('should create a transaction with valid category', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -111,20 +193,18 @@ describe('TransactionsService', () => {
       const transaction = await service.createTransaction(createDto);
 
       expect(transaction).toBeDefined();
-      expect(transaction.id).toBe(1);
+      expect(transaction.id).toBeDefined();
       expect(transaction.amount).toBe(1000);
-      expect(transaction.type).toBe('income');
+      expect(transaction.type).toBe(TransactionType.INCOME);
       expect(transaction.categoryId).toBe(categoryId);
-      expect(transaction.date).toBe('2025-01-01');
+      expect(transaction.date).toBe('2025-01-01T00:00:00.000Z');
       expect(transaction.description).toBe('Monthly salary');
     });
 
-    it('should auto-increment transaction IDs', async () => {
+    it('should create unique transaction IDs', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -137,12 +217,17 @@ describe('TransactionsService', () => {
       const transaction1 = await service.createTransaction(createDto);
       const transaction2 = await service.createTransaction(createDto);
 
-      expect(transaction1.id).toBe(1);
-      expect(transaction2.id).toBe(2);
+      expect(transaction1.id).not.toBe(transaction2.id);
     });
 
     it('should throw BadRequestException if category does not exist', async () => {
-      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue(null);
+      jest
+        .spyOn(categoriesService, 'getCategoryById')
+        .mockRejectedValue(
+          new NotFoundException(
+            `Category with ID ${otherCategoryId} not found`,
+          ),
+        );
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -162,10 +247,8 @@ describe('TransactionsService', () => {
 
     it('should persist transaction in memory', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -176,7 +259,7 @@ describe('TransactionsService', () => {
       };
 
       await service.createTransaction(createDto);
-      const allTransactions = service.getAllTransactions();
+      const allTransactions = await service.getAllTransactions();
 
       expect(allTransactions.length).toBe(1);
       expect(allTransactions[0].amount).toBe(1000);
@@ -186,10 +269,8 @@ describe('TransactionsService', () => {
   describe('updateTransaction', () => {
     beforeEach(async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -207,7 +288,10 @@ describe('TransactionsService', () => {
         amount: 2000,
       };
 
-      const result = await service.updateTransaction(999, updateDto);
+      const result = await service.updateTransaction(
+        missingTransactionId,
+        updateDto,
+      );
       expect(result).toBeNull();
     });
 
@@ -216,9 +300,13 @@ describe('TransactionsService', () => {
         amount: 2000,
       };
 
-      const updated = await service.updateTransaction(1, updateDto);
+      const [existing] = await service.getAllTransactions();
+      const updated = await service.updateTransaction(existing.id, updateDto);
 
       expect(updated).toBeDefined();
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
       expect(updated.amount).toBe(2000);
       expect(updated.description).toBe('Monthly salary');
       expect(updated.categoryId).toBe(categoryId);
@@ -228,15 +316,19 @@ describe('TransactionsService', () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
         description: 'Bonus payment',
-        type: 'bonus',
+        type: 'expense',
       };
 
-      const updated = await service.updateTransaction(1, updateDto);
+      const [existing] = await service.getAllTransactions();
+      const updated = await service.updateTransaction(existing.id, updateDto);
 
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
       expect(updated.amount).toBe(2000);
       expect(updated.description).toBe('Bonus payment');
-      expect(updated.type).toBe('bonus');
-      expect(updated.date).toBe('2025-01-01');
+      expect(updated.type).toBe(TransactionType.EXPENSE);
+      expect(updated.date).toBe('2025-01-01T00:00:00.000Z');
     });
 
     it('should validate category when updating categoryId', async () => {
@@ -251,18 +343,26 @@ describe('TransactionsService', () => {
       await service.createTransaction(createDto);
 
       // Mock the method to return null for invalid category
-      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue(null);
+      jest
+        .spyOn(categoriesService, 'getCategoryById')
+        .mockRejectedValue(
+          new NotFoundException(
+            `Category with ID ${otherCategoryId} not found`,
+          ),
+        );
 
       const updateDto: UpdateTransactionDto = {
         categoryId: otherCategoryId,
       };
 
-      await expect(service.updateTransaction(1, updateDto)).rejects.toThrow(
-        BadRequestException,
-      );
-      await expect(service.updateTransaction(1, updateDto)).rejects.toThrow(
-        `Category with ID ${otherCategoryId} does not exist`,
-      );
+      const [existing] = await service.getAllTransactions();
+
+      await expect(
+        service.updateTransaction(existing.id, updateDto),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.updateTransaction(existing.id, updateDto),
+      ).rejects.toThrow(`Category with ID ${otherCategoryId} does not exist`);
     });
 
     it('should not validate category if categoryId is not being updated', async () => {
@@ -270,26 +370,28 @@ describe('TransactionsService', () => {
         amount: 2000,
       };
 
-      const updated = await service.updateTransaction(1, updateDto);
+      const [existing] = await service.getAllTransactions();
+      const updated = await service.updateTransaction(existing.id, updateDto);
 
       expect(updated).toBeDefined();
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
       expect(updated.amount).toBe(2000);
-      expect(categoriesService.getCategoryById).toHaveBeenCalledTimes(1); // Only called during create
+      expect(
+        (categoriesService.getCategoryById as jest.Mock).mock.calls.length,
+      ).toBe(1); // Only called during create
     });
 
     it('should update category if new category exists', async () => {
       jest
         .spyOn(categoriesService, 'getCategoryById')
         .mockResolvedValueOnce({
-          id: categoryId,
-          name: 'Salary',
-          type: 'income',
-        } as any)
+          ...buildCategory(categoryId, 'Salary'),
+        })
         .mockResolvedValueOnce({
-          id: otherCategoryId,
-          name: 'Bonus',
-          type: 'income',
-        } as any);
+          ...buildCategory(otherCategoryId, 'Bonus'),
+        });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -305,8 +407,12 @@ describe('TransactionsService', () => {
         categoryId: otherCategoryId,
       };
 
-      const updated = await service.updateTransaction(1, updateDto);
+      const [existing] = await service.getAllTransactions();
+      const updated = await service.updateTransaction(existing.id, updateDto);
 
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
       expect(updated.categoryId).toBe(otherCategoryId);
     });
   });
@@ -314,10 +420,8 @@ describe('TransactionsService', () => {
   describe('deleteTransaction', () => {
     beforeEach(async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -330,32 +434,35 @@ describe('TransactionsService', () => {
       await service.createTransaction(createDto);
     });
 
-    it('should return null if transaction does not exist', () => {
-      const result = service.deleteTransaction(999);
+    it('should return null if transaction does not exist', async () => {
+      const result = await service.deleteTransaction(missingTransactionId);
       expect(result).toBeNull();
     });
 
-    it('should delete a transaction and return it', () => {
-      const deleted = service.deleteTransaction(1);
+    it('should delete a transaction and return it', async () => {
+      const [existing] = await service.getAllTransactions();
+      const deleted = await service.deleteTransaction(existing.id);
 
       expect(deleted).toBeDefined();
-      expect(deleted.id).toBe(1);
+      if (!deleted) {
+        throw new Error('Expected deleted transaction to be defined');
+      }
+      expect(deleted.id).toBe(existing.id);
       expect(deleted.amount).toBe(1000);
     });
 
-    it('should remove transaction from array', () => {
-      service.deleteTransaction(1);
-      const remaining = service.getAllTransactions();
+    it('should remove transaction from array', async () => {
+      const [existing] = await service.getAllTransactions();
+      await service.deleteTransaction(existing.id);
+      const remaining = await service.getAllTransactions();
 
       expect(remaining.length).toBe(0);
     });
 
     it('should remove only the specified transaction', async () => {
       jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
-        id: categoryId,
-        name: 'Salary',
-        type: 'income',
-      } as any);
+        ...buildCategory(categoryId, 'Salary'),
+      });
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
@@ -367,11 +474,12 @@ describe('TransactionsService', () => {
 
       await service.createTransaction(createDto);
 
-      service.deleteTransaction(1);
-      const remaining = service.getAllTransactions();
+      const [first] = await service.getAllTransactions();
+      await service.deleteTransaction(first.id);
+      const remaining = await service.getAllTransactions();
 
       expect(remaining.length).toBe(1);
-      expect(remaining[0].id).toBe(2);
+      expect(remaining[0].id).not.toBe(first.id);
     });
   });
 });


### PR DESCRIPTION
…ed types

- inject PrismaService and replace in-memory storage
- validate UUID/date strings in DTOs
- enforce UUID params in controller
- update tests for Prisma-backed behavior and enums