### PR TITLE
refactor(budgets): move BudgetService to Prisma with UUIDs and db ana…

### DIFF
--- a/src/modules/budgets/budget.controller.ts
+++ b/src/modules/budgets/budget.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Delete,
   Put,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { BudgetService } from './budget.service';
 import { CreateBudgetDto } from './dto/create-budget.dto';
@@ -16,35 +17,37 @@ export class BudgetController {
   constructor(private readonly budgetService: BudgetService) {}
 
   @Get()
-  getAllBudgets() {
+  async getAllBudgets() {
     return this.budgetService.getAllBudgets();
   }
 
   @Get(':id')
-  getBudgetById(@Param('id') id: string) {
-    return this.budgetService.getBudgetById(+id);
+  async getBudgetById(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.budgetService.getBudgetById(id);
   }
 
   @Get(':id/details')
-  getBudgetsWithTransactions(@Param('id') id: string) {
-    return this.budgetService.getBudgetsWithTransactions(+id);
+  async getBudgetsWithTransactions(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ) {
+    return this.budgetService.getBudgetsWithTransactions(id);
   }
 
   @Get('category/:categoryId')
   getBudgetsByCategory(
-    @Param('categoryId') categoryId: string,
+    @Param('categoryId', new ParseUUIDPipe()) categoryId: string,
   ): ReturnType<BudgetService['getBudgetsByCategory']> {
     return this.budgetService.getBudgetsByCategory(categoryId);
   }
 
   @Post()
-  createBudget(@Body() budgetData: CreateBudgetDto) {
+  async createBudget(@Body() budgetData: CreateBudgetDto) {
     return this.budgetService.createBudget(budgetData);
   }
 
   @Put(':id')
-  updateBudget(
-    @Param('id') id: number,
+  async updateBudget(
+    @Param('id', new ParseUUIDPipe()) id: string,
     @Body()
     budgetData: UpdateBudgetDto,
   ) {
@@ -52,7 +55,7 @@ export class BudgetController {
   }
 
   @Delete(':id')
-  deleteBudget(@Param('id') id: number) {
+  async deleteBudget(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.budgetService.deleteBudget(id);
   }
 }

--- a/src/modules/budgets/budget.module.ts
+++ b/src/modules/budgets/budget.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { BudgetController } from './budget.controller';
 import { BudgetService } from './budget.service';
 import { CategoriesModule } from '../categories/categories.module';
-import { TransactionsModule } from '../transactions/transactions.module';
+import { SharedModule } from '../shared/shared.module';
 
 @Module({
-  imports: [CategoriesModule, TransactionsModule],
+  imports: [CategoriesModule, SharedModule],
   controllers: [BudgetController],
   providers: [BudgetService],
   exports: [BudgetService],

--- a/src/modules/budgets/dto/create-budget.dto.ts
+++ b/src/modules/budgets/dto/create-budget.dto.ts
@@ -1,14 +1,17 @@
-import { IsNumber, IsString } from 'class-validator';
+import { IsEnum, IsNumber, IsUUID } from 'class-validator';
+import { BudgetType } from '@prisma/client';
 
 export class CreateBudgetDto {
   @IsNumber()
   amount: number;
-  @IsString()
+
+  @IsUUID()
   categoryId: string;
   @IsNumber()
   month: number;
   @IsNumber()
   year: number;
-  @IsString()
-  type: string;
+
+  @IsEnum(BudgetType)
+  type: BudgetType;
 }

--- a/src/modules/budgets/dto/update-budget.dto.ts
+++ b/src/modules/budgets/dto/update-budget.dto.ts
@@ -1,14 +1,24 @@
-import { IsNumber, IsString } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsUUID } from 'class-validator';
+import { BudgetType } from '@prisma/client';
 
 export class UpdateBudgetDto {
+  @IsOptional()
   @IsNumber()
   amount?: number;
-  @IsString()
+
+  @IsOptional()
+  @IsUUID()
   categoryId?: string;
+
+  @IsOptional()
   @IsNumber()
   month?: number;
+
+  @IsOptional()
   @IsNumber()
   year?: number;
-  @IsString()
-  type?: string;
+
+  @IsOptional()
+  @IsEnum(BudgetType)
+  type?: BudgetType;
 }


### PR DESCRIPTION
…lytics

- inject PrismaService and replace in-memory CRUD
- normalize BudgetType enums and validate UUIDs in DTOs
- update controller UUID params and async handlers
- adjust budget analytics to query transactions in DB
- update tests for Prisma mocks and UUID expectations