### PR TITLE
feat: add database seed for default categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "db:migrate:dev": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:generate": "prisma generate",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -59,6 +60,9 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/prisma/migrations/20260215185535_add_unique_constraint_category_name_type/migration.sql
+++ b/prisma/migrations/20260215185535_add_unique_constraint_category_name_type/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name,type]` on the table `Category` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_name_type_key" ON "Category"("name", "type");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model Category {
   updatedAt    DateTime @updatedAt
   transactions Transaction[]
   budgets      Budget[]
+
+  @@unique([name, type])
 }
 
 model Transaction {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,57 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Starting seed...');
+
+  // Income categories
+  const incomeCategories = [
+    { name: 'Salary', type: 'INCOME' },
+    { name: 'Freelance', type: 'INCOME' },
+    { name: 'Investments', type: 'INCOME' },
+  ];
+
+  // Expense categories
+  const expenseCategories = [
+    { name: 'Food', type: 'EXPENSE' },
+    { name: 'Transport', type: 'EXPENSE' },
+    { name: 'Housing', type: 'EXPENSE' },
+    { name: 'Entertainment', type: 'EXPENSE' },
+    { name: 'Healthcare', type: 'EXPENSE' },
+    { name: 'Utilities', type: 'EXPENSE' },
+    { name: 'Shopping', type: 'EXPENSE' },
+    { name: 'Education', type: 'EXPENSE' },
+  ];
+
+  const allCategories = [...incomeCategories, ...expenseCategories];
+
+  // Upsert categories
+  for (const category of allCategories) {
+    await prisma.category.upsert({
+      where: {
+        name_type: {
+          name: category.name,
+          type: category.type as 'INCOME' | 'EXPENSE',
+        },
+      },
+      update: {},
+      create: {
+        name: category.name,
+        type: category.type as 'INCOME' | 'EXPENSE',
+      },
+    });
+    console.log(`✓ Upserted category: ${category.name} (${category.type})`);
+  }
+
+  console.log('Seed completed successfully!');
+}
+
+main()
+  .catch((e) => {
+    console.error('Error during seed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
- Create prisma/seed.ts with 11 default categories (3 income, 8 expense)
- Add unique constraint on Category name+type for upsert operations
- Configure seed command in package.json (npm run db:seed)
- Implement idempotent seed using upsert to prevent duplicates

Categories seeded:
- Income: Salary, Freelance, Investments
- Expense: Food, Transport, Housing, Entertainment, Healthcare, Utilities, Shopping, Education

Migration: 20260215185535_add_unique_constraint_category_name_type