### PR TITLE
refactor: rename BudgetType enum SAVINGS to INCOME

### DIFF
--- a/prisma/migrations/20260215192625_rename_budget_type_savings_to_income/migration.sql
+++ b/prisma/migrations/20260215192625_rename_budget_type_savings_to_income/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - The values [SAVINGS] on the enum `BudgetType` will be renamed to INCOME.
+
+*/
+-- AlterEnum - Rename SAVINGS to INCOME in BudgetType
+ALTER TYPE "BudgetType" RENAME VALUE 'SAVINGS' TO 'INCOME';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ enum TransactionType {
 
 enum BudgetType {
   EXPENSE
-  SAVINGS
+  INCOME
 }
 
 model Category {

--- a/src/modules/budgets/budget.service.ts
+++ b/src/modules/budgets/budget.service.ts
@@ -53,8 +53,8 @@ export class BudgetService {
       return BudgetType.EXPENSE;
     }
 
-    if (normalized === BudgetType.SAVINGS) {
-      return BudgetType.SAVINGS;
+    if (normalized === BudgetType.INCOME) {
+      return BudgetType.INCOME;
     }
 
     throw new BadRequestException(`Invalid budget type: ${type}`);


### PR DESCRIPTION
- Update BudgetType enum in schema.prisma from SAVINGS to INCOME
- Modify normalizeBudgetType method in budget.service.ts to use INCOME
- Create migration to rename enum value in PostgreSQL database
- Ensure consistency with CategoryType and TransactionType enums

Migration: 20260215192625_rename_budget_type_savings_to_income

This change maintains domain model consistency across all type enums and automatically converts existing SAVINGS budgets to INCOME.