### PR TITLE
feat: add AuthsModule base structure

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { HealthModule } from './modules/health/health.module';
 import { CategoriesModule } from './modules/categories/categories.module';
 import { TransactionsModule } from './modules/transactions/transactions.module';
 import { BudgetModule } from './modules/budgets/budget.module';
+import { AuthsModule } from './modules/auths/auths.module';
 import { SharedModule } from './modules/shared';
 
 @Module({
@@ -14,6 +15,7 @@ import { SharedModule } from './modules/shared';
     CategoriesModule,
     TransactionsModule,
     BudgetModule,
+    AuthsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/auths/auths.controller.ts
+++ b/src/modules/auths/auths.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { AuthsService } from './auths.service';
+
+@Controller('auths')
+export class AuthsController {
+  constructor(private readonly authsService: AuthsService) {}
+}

--- a/src/modules/auths/auths.module.ts
+++ b/src/modules/auths/auths.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthsService } from './auths.service';
+import { AuthsController } from './auths.controller';
+import { SharedModule } from '../shared/shared.module';
+
+@Module({
+  imports: [SharedModule],
+  controllers: [AuthsController],
+  providers: [AuthsService],
+  exports: [AuthsService],
+})
+export class AuthsModule {}

--- a/src/modules/auths/auths.service.spec.ts
+++ b/src/modules/auths/auths.service.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthsService } from './auths.service';
+import { PrismaService } from '../shared/prisma.service';
+
+describe('AuthsService', () => {
+  let service: AuthsService;
+  let prismaService: PrismaService;
+
+  const prismaMock = {
+    // Add prisma methods here as needed
+  } as unknown as PrismaService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthsService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthsService>(AuthsService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/auths/auths.service.ts
+++ b/src/modules/auths/auths.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../shared/prisma.service';
+
+@Injectable()
+export class AuthsService {
+  constructor(private readonly prisma: PrismaService) {}
+}


### PR DESCRIPTION
- Create AuthsModule with SharedModule import
- Add AuthsController with auths route
- Add AuthsService with PrismaService injection
- Export AuthsService for use by other modules
- Add AuthsService unit test with basic structure
- Register AuthsModule in AppModule

The module provides the foundation for future authentication implementation without including JWT or login/register endpoints.