### PR TITLE
feat: add User model with multi-user support and cascade relations

### DIFF
--- a/prisma/migrations/20260216234957_add_user_model_and_relations/migration.sql
+++ b/prisma/migrations/20260216234957_add_user_model_and_relations/migration.sql
@@ -1,0 +1,54 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[categoryId,month,year,userId]` on the table `Budget` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[name,type,userId]` on the table `Category` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `userId` to the `Budget` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Category` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "Budget_categoryId_month_year_type_key";
+
+-- DropIndex
+DROP INDEX "Category_name_type_key";
+
+-- AlterTable
+ALTER TABLE "Budget" ADD COLUMN     "userId" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "userId" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "userId" UUID NOT NULL;
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Budget_categoryId_month_year_userId_key" ON "Budget"("categoryId", "month", "year", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_name_type_userId_key" ON "Category"("name", "type", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,16 +25,30 @@ enum BudgetType {
   INCOME
 }
 
+model User {
+  id           String        @id @default(uuid()) @db.Uuid
+  name         String
+  email        String        @unique
+  password     String
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  categories   Category[]
+  transactions Transaction[]
+  budgets      Budget[]
+}
+
 model Category {
   id           String   @id @default(uuid()) @db.Uuid
   name         String
   type         CategoryType
+  userId       String   @db.Uuid
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   transactions Transaction[]
   budgets      Budget[]
 
-  @@unique([name, type])
+  @@unique([name, type, userId])
 }
 
 model Transaction {
@@ -45,6 +59,8 @@ model Transaction {
   type        TransactionType
   categoryId  String          @db.Uuid
   category    Category        @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  userId      String          @db.Uuid
+  user        User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt   DateTime        @default(now())
   updatedAt   DateTime        @updatedAt
 }
@@ -57,8 +73,10 @@ model Budget {
   type         BudgetType
   categoryId   String     @db.Uuid
   category     Category   @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  userId       String     @db.Uuid
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
 
-  @@unique([categoryId, month, year, type])
+  @@unique([categoryId, month, year, userId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,6 +5,18 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('Starting seed...');
 
+  // Create default user
+  const user = await prisma.user.upsert({
+    where: { email: 'demo@example.com' },
+    update: {},
+    create: {
+      name: 'Demo User',
+      email: 'demo@example.com',
+      password: 'password123', // Note: This is just for seeding. In production, use hashed passwords.
+    },
+  });
+  console.log(`✓ Upserted user: ${user.email}`);
+
   // Income categories
   const incomeCategories = [
     { name: 'Salary', type: 'INCOME' },
@@ -30,15 +42,17 @@ async function main() {
   for (const category of allCategories) {
     await prisma.category.upsert({
       where: {
-        name_type: {
+        name_type_userId: {
           name: category.name,
           type: category.type as 'INCOME' | 'EXPENSE',
+          userId: user.id,
         },
       },
       update: {},
       create: {
         name: category.name,
         type: category.type as 'INCOME' | 'EXPENSE',
+        userId: user.id,
       },
     });
     console.log(`✓ Upserted category: ${category.name} (${category.type})`);


### PR DESCRIPTION
- Create User model with id, name, email, password, createdAt, updatedAt
- Add unique constraint on User.email
- Add userId foreign key to Category, Transaction, and Budget models
- Enable CASCADE delete on all User relations
- Update unique constraints to be scoped per user:
  - Category: @@unique([name, type, userId])
  - Budget: @@unique([categoryId, month, year, userId])
- Create and apply migration: add_user_model_and_relations
- Update seed script to create demo user (demo@example.com)
- Update seed to associate categories with demo user

This enables multi-user data isolation with automatic cleanup when users are deleted.