### PR TITLE
feat: add userId ownership validation to categories

### DIFF
--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -11,23 +11,29 @@ import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 
+// TODO: Replace with actual userId from authentication context
+const DEMO_USER_ID = 'd1a2b3c4-0000-0000-0000-000000000000';
+
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Get()
   getAllCategories() {
-    return this.categoriesService.getAllCategories();
+    return this.categoriesService.getAllCategories(DEMO_USER_ID);
   }
 
   @Get(':id')
   getCategoryById(@Param('id') id: string) {
-    return this.categoriesService.getCategoryById(id);
+    return this.categoriesService.getCategoryById(id, DEMO_USER_ID);
   }
 
   @Post()
   createCategory(@Body() createCategoryDto: CreateCategoryDto) {
-    return this.categoriesService.createCategory(createCategoryDto);
+    return this.categoriesService.createCategory(
+      createCategoryDto,
+      DEMO_USER_ID,
+    );
   }
 
   @Put(':id')
@@ -35,11 +41,15 @@ export class CategoriesController {
     @Param('id') id: string,
     @Body() updateCategoryDto: UpdateCategoryDto,
   ) {
-    return this.categoriesService.updateCategory(id, updateCategoryDto);
+    return this.categoriesService.updateCategory(
+      id,
+      updateCategoryDto,
+      DEMO_USER_ID,
+    );
   }
 
   @Delete(':id')
   deleteCategory(@Param('id') id: string) {
-    return this.categoriesService.deleteCategory(id);
+    return this.categoriesService.deleteCategory(id, DEMO_USER_ID);
   }
 }

--- a/src/modules/categories/categories.service.ts
+++ b/src/modules/categories/categories.service.ts
@@ -12,8 +12,9 @@ import { PrismaService } from '../shared/prisma.service';
 export class CategoriesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getAllCategories() {
+  async getAllCategories(userId: string) {
     const categories = await this.prisma.category.findMany({
+      where: { userId },
       orderBy: {
         name: 'asc',
       },
@@ -22,9 +23,9 @@ export class CategoriesService {
     return categories.map((category) => this.toApiCategory(category));
   }
 
-  async getCategoryById(id: string) {
+  async getCategoryById(id: string, userId: string) {
     const category = await this.prisma.category.findUnique({
-      where: { id },
+      where: { id, userId },
     });
 
     if (!category) {
@@ -34,19 +35,24 @@ export class CategoriesService {
     return this.toApiCategory(category);
   }
 
-  async createCategory(createCategoryDto: CreateCategoryDto) {
+  async createCategory(createCategoryDto: CreateCategoryDto, userId: string) {
     const category = await this.prisma.category.create({
       data: {
         name: createCategoryDto.name,
         type: this.normalizeCategoryType(createCategoryDto.type),
+        userId,
       },
     });
 
     return this.toApiCategory(category);
   }
 
-  async updateCategory(id: string, updateCategoryDto: UpdateCategoryDto) {
-    await this.ensureCategoryExists(id);
+  async updateCategory(
+    id: string,
+    updateCategoryDto: UpdateCategoryDto,
+    userId: string,
+  ) {
+    await this.ensureCategoryExists(id, userId);
 
     const data: { name?: string; type?: CategoryType } = {};
 
@@ -66,8 +72,8 @@ export class CategoriesService {
     return this.toApiCategory(category);
   }
 
-  async deleteCategory(id: string) {
-    await this.ensureCategoryExists(id);
+  async deleteCategory(id: string, userId: string) {
+    await this.ensureCategoryExists(id, userId);
 
     const category = await this.prisma.category.delete({
       where: { id },
@@ -93,9 +99,9 @@ export class CategoriesService {
     };
   }
 
-  private async ensureCategoryExists(id: string) {
+  private async ensureCategoryExists(id: string, userId: string) {
     const category = await this.prisma.category.findUnique({
-      where: { id },
+      where: { id, userId },
       select: { id: true },
     });
 


### PR DESCRIPTION
- Add userId parameter to all category service methods (create, read, update, delete)
- Enforce user ownership checks in service layer for all CRUD operations
- Update controller to pass DEMO_USER_ID to service methods
- Expand unit tests to verify userId filtering and unauthorized access prevention
- Add tests for cross-user access attempts (read, update, delete)
- Ensure categories are scoped to their owning user

This implements the Category-User relationship established in the database schema, ensuring users can only access, modify, or delete their own categories.