### PR TITLE
feat: add userId ownership validation to transactions

### DIFF
--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -11,23 +11,30 @@ import {
 import { TransactionsService } from './transactions.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+
+// TODO: Replace with actual userId from authentication context
+const DEMO_USER_ID = 'd1a2b3c4-0000-0000-0000-000000000000';
+
 @Controller('transactions')
 export class TransactionController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
   @Get()
   async getAllTransactions() {
-    return this.transactionsService.getAllTransactions();
+    return this.transactionsService.getAllTransactions(DEMO_USER_ID);
   }
 
   @Get(':id')
   async getTransactionById(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.transactionsService.getTransactionById(id);
+    return this.transactionsService.getTransactionById(id, DEMO_USER_ID);
   }
 
   @Post()
   async createTransaction(@Body() createTransactionDto: CreateTransactionDto) {
-    return this.transactionsService.createTransaction(createTransactionDto);
+    return this.transactionsService.createTransaction(
+      createTransactionDto,
+      DEMO_USER_ID,
+    );
   }
 
   @Put(':id')
@@ -35,11 +42,15 @@ export class TransactionController {
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateTransactionDto: UpdateTransactionDto,
   ) {
-    return this.transactionsService.updateTransaction(id, updateTransactionDto);
+    return this.transactionsService.updateTransaction(
+      id,
+      updateTransactionDto,
+      DEMO_USER_ID,
+    );
   }
 
   @Delete(':id')
   async deleteTransaction(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.transactionsService.deleteTransaction(id);
+    return this.transactionsService.deleteTransaction(id, DEMO_USER_ID);
   }
 }

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -51,16 +51,17 @@ export class TransactionsService {
     description: true,
   };
 
-  async getAllTransactions() {
+  async getAllTransactions(userId: string) {
     const transactions = await this.prisma.transaction.findMany({
+      where: { userId },
       select: this.transactionSelect,
     });
     return transactions.map((transaction) => this.mapTransaction(transaction));
   }
 
-  async getTransactionById(id: string) {
+  async getTransactionById(id: string, userId: string) {
     const transaction = await this.prisma.transaction.findUnique({
-      where: { id },
+      where: { id, userId },
       select: this.transactionSelect,
     });
     if (!transaction) {
@@ -69,13 +70,17 @@ export class TransactionsService {
     return this.mapTransaction(transaction);
   }
 
-  async createTransaction(createTransactionDto: CreateTransactionDto) {
+  async createTransaction(
+    createTransactionDto: CreateTransactionDto,
+    userId: string,
+  ) {
     // Validate category existence
     let category = null;
 
     try {
       category = await this.categoriesService.getCategoryById(
         createTransactionDto.categoryId,
+        userId,
       );
     } catch (error) {
       if (!(error instanceof NotFoundException)) {
@@ -96,6 +101,7 @@ export class TransactionsService {
         categoryId: createTransactionDto.categoryId,
         date: new Date(createTransactionDto.date),
         description: createTransactionDto.description,
+        userId,
       },
       select: this.transactionSelect,
     });
@@ -105,6 +111,7 @@ export class TransactionsService {
   async updateTransaction(
     id: string,
     updateTransactionDto: UpdateTransactionDto,
+    userId: string,
   ) {
     // Validate category existence if categoryId is being updated
     if (updateTransactionDto.categoryId !== undefined) {
@@ -113,6 +120,7 @@ export class TransactionsService {
       try {
         category = await this.categoriesService.getCategoryById(
           updateTransactionDto.categoryId,
+          userId,
         );
       } catch (error) {
         if (!(error instanceof NotFoundException)) {
@@ -157,9 +165,9 @@ export class TransactionsService {
     return this.mapTransaction(updatedTransaction);
   }
 
-  async deleteTransaction(id: string) {
+  async deleteTransaction(id: string, userId: string) {
     const existingTransaction = await this.prisma.transaction.findUnique({
-      where: { id },
+      where: { id, userId },
       select: this.transactionSelect,
     });
 


### PR DESCRIPTION
- Add userId parameter to all transaction service methods (create, read, update, delete)
- Enforce user ownership checks in service layer for all CRUD operations
- Update controller to pass DEMO_USER_ID to service methods
- Add userId filtering in Prisma queries (findMany, findUnique, create)
- Pass userId when validating category existence in transaction operations
- Expand unit tests to verify userId filtering and unauthorized access prevention
- Add tests for cross-user access attempts (read, update, delete)
- Ensure transactions are scoped to their owning user

This implements the Transaction-User relationship established in the database schema, ensuring users can only access, modify, or delete their own transactions.