### PR TITLE
feat(auth): add login endpoint with DTO and bcrypt validation

### DIFF
--- a/src/modules/auths/auths.controller.ts
+++ b/src/modules/auths/auths.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { AuthsService } from './auths.service';
 import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
 
 @Controller('auths')
 export class AuthsController {
@@ -9,5 +10,10 @@ export class AuthsController {
   @Post('register')
   async register(@Body() registerDto: RegisterDto) {
     return this.authsService.register(registerDto);
+  }
+
+  @Post('login')
+  async login(@Body() loginDto: LoginDto) {
+    return this.authsService.login(loginDto);
   }
 }

--- a/src/modules/auths/dto/login.dto.ts
+++ b/src/modules/auths/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(6)
+  password: string;
+}


### PR DESCRIPTION
- add LoginDto with email/password validation
- expose POST /auths/login controller action
- validate credentials and return JWT access token
- return UnauthorizedException with “Invalid credentials” on failure