### PR TITLE
feat(auth): protect routes with JWT authentication guard

### DIFF
--- a/src/modules/auths/auths.module.ts
+++ b/src/modules/auths/auths.module.ts
@@ -6,6 +6,7 @@ import { AuthsService } from './auths.service';
 import { AuthsController } from './auths.controller';
 import { SharedModule } from '../shared/shared.module';
 import { JwtStrategy } from './jwt.strategy';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Module({
   imports: [
@@ -14,7 +15,7 @@ import { JwtStrategy } from './jwt.strategy';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => {
+      useFactory: (configService: ConfigService) => {
         const secret = configService.get<string>('JWT_SECRET');
         const expiresIn = configService.get<number>('JWT_EXPIRATION');
 
@@ -38,7 +39,7 @@ import { JwtStrategy } from './jwt.strategy';
     }),
   ],
   controllers: [AuthsController],
-  providers: [AuthsService, JwtStrategy],
-  exports: [AuthsService, JwtService],
+  providers: [AuthsService, JwtStrategy, JwtAuthGuard],
+  exports: [AuthsService, JwtAuthGuard],
 })
 export class AuthsModule {}

--- a/src/modules/auths/interfaces/authenticated-request.interface.ts
+++ b/src/modules/auths/interfaces/authenticated-request.interface.ts
@@ -1,0 +1,9 @@
+export interface AuthenticatedUser {
+  userId: string;
+  email: string;
+  name: string;
+}
+
+export interface AuthenticatedRequest {
+  user: AuthenticatedUser;
+}

--- a/src/modules/auths/jwt-auth.guard.ts
+++ b/src/modules/auths/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/modules/budgets/budget.controller.ts
+++ b/src/modules/budgets/budget.controller.ts
@@ -7,45 +7,55 @@ import {
   Delete,
   Put,
   ParseUUIDPipe,
+  UseGuards,
+  Request,
 } from '@nestjs/common';
 import { BudgetService } from './budget.service';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
-
-// TODO: Replace with actual userId from authentication context
-const DEMO_USER_ID = 'd1a2b3c4-0000-0000-0000-000000000000';
+import { JwtAuthGuard } from '../auths/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
 @Controller('budgets')
+@UseGuards(JwtAuthGuard)
 export class BudgetController {
   constructor(private readonly budgetService: BudgetService) {}
 
   @Get()
-  async getAllBudgets() {
-    return this.budgetService.getAllBudgets(DEMO_USER_ID);
+  async getAllBudgets(@Request() req: AuthenticatedRequest) {
+    return this.budgetService.getAllBudgets(req.user.userId);
   }
 
   @Get(':id')
-  async getBudgetById(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.budgetService.getBudgetById(id, DEMO_USER_ID);
+  async getBudgetById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.budgetService.getBudgetById(id, req.user.userId);
   }
 
   @Get(':id/details')
   async getBudgetsWithTransactions(
     @Param('id', new ParseUUIDPipe()) id: string,
+    @Request() req: AuthenticatedRequest,
   ) {
-    return this.budgetService.getBudgetsWithTransactions(id, DEMO_USER_ID);
+    return this.budgetService.getBudgetsWithTransactions(id, req.user.userId);
   }
 
   @Get('category/:categoryId')
   getBudgetsByCategory(
     @Param('categoryId', new ParseUUIDPipe()) categoryId: string,
+    @Request() req: AuthenticatedRequest,
   ): ReturnType<BudgetService['getBudgetsByCategory']> {
-    return this.budgetService.getBudgetsByCategory(categoryId, DEMO_USER_ID);
+    return this.budgetService.getBudgetsByCategory(categoryId, req.user.userId);
   }
 
   @Post()
-  async createBudget(@Body() budgetData: CreateBudgetDto) {
-    return this.budgetService.createBudget(budgetData, DEMO_USER_ID);
+  async createBudget(
+    @Body() budgetData: CreateBudgetDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.budgetService.createBudget(budgetData, req.user.userId);
   }
 
   @Put(':id')
@@ -53,12 +63,16 @@ export class BudgetController {
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body()
     budgetData: UpdateBudgetDto,
+    @Request() req: AuthenticatedRequest,
   ) {
-    return this.budgetService.updateBudget(id, budgetData, DEMO_USER_ID);
+    return this.budgetService.updateBudget(id, budgetData, req.user.userId);
   }
 
   @Delete(':id')
-  async deleteBudget(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.budgetService.deleteBudget(id, DEMO_USER_ID);
+  async deleteBudget(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.budgetService.deleteBudget(id, req.user.userId);
   }
 }

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -6,33 +6,41 @@ import {
   Param,
   Delete,
   Put,
+  UseGuards,
+  Request,
 } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
-
-// TODO: Replace with actual userId from authentication context
-const DEMO_USER_ID = 'd1a2b3c4-0000-0000-0000-000000000000';
+import { JwtAuthGuard } from '../auths/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
 @Controller('categories')
+@UseGuards(JwtAuthGuard)
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Get()
-  getAllCategories() {
-    return this.categoriesService.getAllCategories(DEMO_USER_ID);
+  getAllCategories(@Request() req: AuthenticatedRequest) {
+    return this.categoriesService.getAllCategories(req.user.userId);
   }
 
   @Get(':id')
-  getCategoryById(@Param('id') id: string) {
-    return this.categoriesService.getCategoryById(id, DEMO_USER_ID);
+  getCategoryById(
+    @Param('id') id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.categoriesService.getCategoryById(id, req.user.userId);
   }
 
   @Post()
-  createCategory(@Body() createCategoryDto: CreateCategoryDto) {
+  createCategory(
+    @Body() createCategoryDto: CreateCategoryDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
     return this.categoriesService.createCategory(
       createCategoryDto,
-      DEMO_USER_ID,
+      req.user.userId,
     );
   }
 
@@ -40,16 +48,20 @@ export class CategoriesController {
   updateCategory(
     @Param('id') id: string,
     @Body() updateCategoryDto: UpdateCategoryDto,
+    @Request() req: AuthenticatedRequest,
   ) {
     return this.categoriesService.updateCategory(
       id,
       updateCategoryDto,
-      DEMO_USER_ID,
+      req.user.userId,
     );
   }
 
   @Delete(':id')
-  deleteCategory(@Param('id') id: string) {
-    return this.categoriesService.deleteCategory(id, DEMO_USER_ID);
+  deleteCategory(
+    @Param('id') id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.categoriesService.deleteCategory(id, req.user.userId);
   }
 }

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -7,33 +7,41 @@ import {
   Delete,
   Put,
   ParseUUIDPipe,
+  UseGuards,
+  Request,
 } from '@nestjs/common';
 import { TransactionsService } from './transactions.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
-
-// TODO: Replace with actual userId from authentication context
-const DEMO_USER_ID = 'd1a2b3c4-0000-0000-0000-000000000000';
+import { JwtAuthGuard } from '../auths/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
 @Controller('transactions')
+@UseGuards(JwtAuthGuard)
 export class TransactionController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
   @Get()
-  async getAllTransactions() {
-    return this.transactionsService.getAllTransactions(DEMO_USER_ID);
+  async getAllTransactions(@Request() req: AuthenticatedRequest) {
+    return this.transactionsService.getAllTransactions(req.user.userId);
   }
 
   @Get(':id')
-  async getTransactionById(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.transactionsService.getTransactionById(id, DEMO_USER_ID);
+  async getTransactionById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.transactionsService.getTransactionById(id, req.user.userId);
   }
 
   @Post()
-  async createTransaction(@Body() createTransactionDto: CreateTransactionDto) {
+  async createTransaction(
+    @Body() createTransactionDto: CreateTransactionDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
     return this.transactionsService.createTransaction(
       createTransactionDto,
-      DEMO_USER_ID,
+      req.user.userId,
     );
   }
 
@@ -41,16 +49,20 @@ export class TransactionController {
   async updateTransaction(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateTransactionDto: UpdateTransactionDto,
+    @Request() req: AuthenticatedRequest,
   ) {
     return this.transactionsService.updateTransaction(
       id,
       updateTransactionDto,
-      DEMO_USER_ID,
+      req.user.userId,
     );
   }
 
   @Delete(':id')
-  async deleteTransaction(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.transactionsService.deleteTransaction(id, DEMO_USER_ID);
+  async deleteTransaction(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.transactionsService.deleteTransaction(id, req.user.userId);
   }
 }


### PR DESCRIPTION
- create JwtAuthGuard extending AuthGuard('jwt')
- add AuthenticatedRequest interface for type-safe user extraction
- apply @UseGuards(JwtAuthGuard) to all controllers
- replace hardcoded DEMO_USER_ID with req.user.userId from JWT
- protect categories, transactions, and budgets routes
- remove async modifier from JWT module useFactory
- export JwtAuthGuard from AuthsModule (remove JwtService export)

All protected routes now require valid JWT token and return 401 for unauthorized requests. User context is extracted from request and passed to service methods.