### PR TITLE
feat: implement complete user data isolation across services

### DIFF
--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -136,7 +136,7 @@ export class TransactionsService {
     }
 
     const existingTransaction = await this.prisma.transaction.findUnique({
-      where: { id },
+      where: { id, userId },
       select: this.transactionSelect,
     });
 
@@ -145,7 +145,7 @@ export class TransactionsService {
     }
 
     const updatedTransaction = await this.prisma.transaction.update({
-      where: { id },
+      where: { id, userId },
       data: {
         amount: updateTransactionDto.amount,
         type:


### PR DESCRIPTION
- Add userId filtering to all Prisma queries in transaction and budget services
- Update transaction.service: filter by userId in findUnique and update operations
- Update budget.service:
  * Add userId parameter to calculateSpentAmount() private method
  * Filter by userId in transaction.aggregate() and transaction.findMany() queries
  * Add userId filtering to budget findUnique and update operations for ownership validation
  * Pass userId to all calculateSpentAmount() calls
- Add userId to transaction queries in getTransactionsForBudget()
- Update test mocks to properly validate userId in update operations
- Add comprehensive isolation tests:
  * Budget update rejects unauthorized users
  * Transaction update rejects unauthorized users
  * getTransactionsForBudget() filters out other users' transactions
  * getSpentAmount() only counts current user's transactions