### PR TITLE
feat(dashboard): add monthly summary endpoint with validation and tests

### DIFF
--- a/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  let service: DashboardService;
+
+  const mockUserId = 'user-123';
+  const mockAuthenticatedRequest = {
+    user: {
+      userId: mockUserId,
+      email: 'test@example.com',
+      name: 'Test User',
+    },
+  } as unknown as AuthenticatedRequest;
+
+  beforeEach(async () => {
+    const mockDashboardService = {
+      getMonthlySummary: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [
+        {
+          provide: DashboardService,
+          useValue: mockDashboardService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+    service = module.get<DashboardService>(DashboardService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getMonthlySummary', () => {
+    it('should return monthly summary for valid month and year', async () => {
+      const expectedResult = {
+        totalIncome: 5000,
+        totalExpense: 2000,
+        balance: 3000,
+      };
+
+      jest
+        .spyOn(service, 'getMonthlySummary')
+        .mockResolvedValue(expectedResult);
+
+      const result = await controller.getMonthlySummary(
+        mockAuthenticatedRequest,
+        2,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getMonthlySummary).toHaveBeenCalledWith(
+        mockUserId,
+        2,
+        2026,
+      );
+    });
+
+    it('should throw BadRequestException for invalid month (0)', async () => {
+      await expect(
+        controller.getMonthlySummary(mockAuthenticatedRequest, 0, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for invalid month (13)', async () => {
+      await expect(
+        controller.getMonthlySummary(mockAuthenticatedRequest, 13, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should accept month 1 (January)', async () => {
+      const expectedResult = {
+        totalIncome: 1000,
+        totalExpense: 500,
+        balance: 500,
+      };
+
+      jest
+        .spyOn(service, 'getMonthlySummary')
+        .mockResolvedValue(expectedResult);
+
+      const result = await controller.getMonthlySummary(
+        mockAuthenticatedRequest,
+        1,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getMonthlySummary).toHaveBeenCalledWith(
+        mockUserId,
+        1,
+        2026,
+      );
+    });
+
+    it('should accept month 12 (December)', async () => {
+      const expectedResult = {
+        totalIncome: 2000,
+        totalExpense: 1000,
+        balance: 1000,
+      };
+
+      jest
+        .spyOn(service, 'getMonthlySummary')
+        .mockResolvedValue(expectedResult);
+
+      const result = await controller.getMonthlySummary(
+        mockAuthenticatedRequest,
+        12,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getMonthlySummary).toHaveBeenCalledWith(
+        mockUserId,
+        12,
+        2026,
+      );
+    });
+
+    it('should return zero values when no transactions exist', async () => {
+      const expectedResult = {
+        totalIncome: 0,
+        totalExpense: 0,
+        balance: 0,
+      };
+
+      jest
+        .spyOn(service, 'getMonthlySummary')
+        .mockResolvedValue(expectedResult);
+
+      const result = await controller.getMonthlySummary(
+        mockAuthenticatedRequest,
+        3,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should use userId from authenticated request', async () => {
+      jest.spyOn(service, 'getMonthlySummary').mockResolvedValue({
+        totalIncome: 0,
+        totalExpense: 0,
+        balance: 0,
+      });
+
+      await controller.getMonthlySummary(mockAuthenticatedRequest, 6, 2026);
+
+      expect(service.getMonthlySummary).toHaveBeenCalledWith(
+        mockUserId,
+        6,
+        2026,
+      );
+    });
+  });
+});

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,4 +1,39 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  ParseIntPipe,
+  BadRequestException,
+  Req,
+} from '@nestjs/common';
+import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
+import { JwtAuthGuard } from '../auths/jwt-auth.guard';
+import { DashboardService } from './dashboard.service';
+import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 
 @Controller('dashboard')
-export class DashboardController {}
+export class DashboardController {
+  constructor(private dashboardService: DashboardService) {}
+
+  private validateMonth(month: number): void {
+    if (month < 1 || month > 12) {
+      throw new BadRequestException(
+        'Invalid month. Month must be between 1 and 12.',
+      );
+    }
+  }
+
+  @Get('monthly-summary')
+  @UseGuards(JwtAuthGuard)
+  async getMonthlySummary(
+    @Req() req: AuthenticatedRequest,
+    @Query('month', ParseIntPipe) month: number,
+    @Query('year', ParseIntPipe) year: number,
+  ): Promise<MonthlySummaryDto> {
+    this.validateMonth(month);
+
+    const userId = req.user.userId;
+    return this.dashboardService.getMonthlySummary(userId, month, year);
+  }
+}

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
+import { SharedModule } from '../shared';
 
 @Module({
+  imports: [SharedModule],
   controllers: [DashboardController],
   providers: [DashboardService],
 })

--- a/src/modules/dashboard/dashboard.service.spec.ts
+++ b/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,181 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TransactionType } from '@prisma/client';
+import { DashboardService } from './dashboard.service';
+import { PrismaService } from '../shared/prisma.service';
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let prismaService: PrismaService;
+
+  const mockUserId = 'user-123';
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      transaction: {
+        findMany: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getMonthlySummary', () => {
+    it('should return correct totals with transactions', async () => {
+      const transactions = [
+        {
+          amount: { toNumber: () => 1000 },
+          type: TransactionType.INCOME,
+        },
+        {
+          amount: { toNumber: () => 500 },
+          type: TransactionType.INCOME,
+        },
+        {
+          amount: { toNumber: () => 300 },
+          type: TransactionType.EXPENSE,
+        },
+        {
+          amount: { toNumber: () => 200 },
+          type: TransactionType.EXPENSE,
+        },
+      ];
+
+      // Convert to the format expected by the service
+      const formattedTransactions = transactions.map((t) => ({
+        amount: t.amount.toNumber ? t.amount.toNumber() : t.amount,
+        type: t.type,
+      }));
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(formattedTransactions as any);
+
+      const result = await service.getMonthlySummary(mockUserId, 2, 2026);
+
+      expect(result).toEqual({
+        totalIncome: 1500,
+        totalExpense: 500,
+        balance: 1000,
+      });
+      expect(prismaService.transaction.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: mockUserId,
+          date: {
+            gte: new Date(Date.UTC(2026, 1, 1, 0, 0, 0, 0)),
+            lt: new Date(Date.UTC(2026, 2, 1, 0, 0, 0, 0)),
+          },
+        },
+        select: {
+          amount: true,
+          type: true,
+        },
+      });
+    });
+
+    it('should return zero values when no transactions exist', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      const result = await service.getMonthlySummary(mockUserId, 1, 2026);
+
+      expect(result).toEqual({
+        totalIncome: 0,
+        totalExpense: 0,
+        balance: 0,
+      });
+    });
+
+    it('should handle only income transactions', async () => {
+      const transactions = [
+        { amount: 500, type: TransactionType.INCOME },
+        { amount: 1000, type: TransactionType.INCOME },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getMonthlySummary(mockUserId, 3, 2026);
+
+      expect(result).toEqual({
+        totalIncome: 1500,
+        totalExpense: 0,
+        balance: 1500,
+      });
+    });
+
+    it('should handle only expense transactions', async () => {
+      const transactions = [
+        { amount: 250, type: TransactionType.EXPENSE },
+        { amount: 150, type: TransactionType.EXPENSE },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getMonthlySummary(mockUserId, 6, 2026);
+
+      expect(result).toEqual({
+        totalIncome: 0,
+        totalExpense: 400,
+        balance: -400,
+      });
+    });
+
+    it('should filter transactions by userId', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      await service.getMonthlySummary(mockUserId, 12, 2026);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.where.userId).toBe(mockUserId);
+    });
+
+    it('should calculate correct date range for February', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      await service.getMonthlySummary(mockUserId, 2, 2026);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.where.date.gte).toEqual(
+        new Date(Date.UTC(2026, 1, 1, 0, 0, 0, 0)),
+      );
+      expect(callArgs.where.date.lt).toEqual(
+        new Date(Date.UTC(2026, 2, 1, 0, 0, 0, 0)),
+      );
+    });
+
+    it('should calculate balance as totalIncome minus totalExpense', async () => {
+      const transactions = [
+        { amount: 5000, type: TransactionType.INCOME },
+        { amount: 2000, type: TransactionType.EXPENSE },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getMonthlySummary(mockUserId, 5, 2026);
+
+      expect(result.balance).toBe(result.totalIncome - result.totalExpense);
+      expect(result.balance).toBe(3000);
+    });
+  });
+});

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -1,4 +1,59 @@
 import { Injectable } from '@nestjs/common';
+import { TransactionType } from '@prisma/client';
+import { PrismaService } from '../shared/prisma.service';
+import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 
 @Injectable()
-export class DashboardService {}
+export class DashboardService {
+  constructor(private prisma: PrismaService) {}
+
+  private getMonthRange(month: number, year: number) {
+    const start = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+    const end = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+    return { start, end };
+  }
+
+  async getMonthlySummary(
+    userId: string,
+    month: number,
+    year: number,
+  ): Promise<MonthlySummaryDto> {
+    const { start, end } = this.getMonthRange(month, year);
+
+    // Fetch all transactions for the month
+    const transactions = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        date: {
+          gte: start,
+          lt: end,
+        },
+      },
+      select: {
+        amount: true,
+        type: true,
+      },
+    });
+
+    // Calculate totals
+    let totalIncome = 0;
+    let totalExpense = 0;
+
+    transactions.forEach((transaction) => {
+      const amount = Number(transaction.amount);
+      if (transaction.type === TransactionType.INCOME) {
+        totalIncome += amount;
+      } else if (transaction.type === TransactionType.EXPENSE) {
+        totalExpense += amount;
+      }
+    });
+
+    const balance = totalIncome - totalExpense;
+
+    return {
+      totalIncome,
+      totalExpense,
+      balance,
+    };
+  }
+}

--- a/src/modules/dashboard/dto/monthly-summary.dto.ts
+++ b/src/modules/dashboard/dto/monthly-summary.dto.ts
@@ -1,0 +1,5 @@
+export class MonthlySummaryDto {
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+}


### PR DESCRIPTION
- add GET /dashboard/monthly-summary with month/year query params and auth guard
- validate month range and return MonthlySummaryDto
- implement service aggregation with UTC month range and user filtering
- add dashboard module dependency on SharedModule
- add controller and service unit tests