### PR TITLE
feat(dashboard): add budget vs actual comparison endpoint

### DIFF
--- a/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/dashboard.controller.spec.ts
@@ -20,6 +20,7 @@ describe('DashboardController', () => {
   beforeEach(async () => {
     const mockDashboardService = {
       getMonthlySummary: jest.fn(),
+      getBudgetVsActual: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -158,6 +159,61 @@ describe('DashboardController', () => {
       await controller.getMonthlySummary(mockAuthenticatedRequest, 6, 2026);
 
       expect(service.getMonthlySummary).toHaveBeenCalledWith(
+        mockUserId,
+        6,
+        2026,
+      );
+    });
+  });
+
+  describe('getBudgetVsActual', () => {
+    it('should return budget vs actual comparison for valid month and year', async () => {
+      const expectedResult = [
+        {
+          category: { id: 'cat-1', name: 'Food', type: 'EXPENSE' },
+          budgetAmount: 1000,
+          actualAmount: 500,
+          difference: 500,
+          percentageUsed: 50,
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getBudgetVsActual')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getBudgetVsActual(
+        mockAuthenticatedRequest,
+        2,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getBudgetVsActual).toHaveBeenCalledWith(
+        mockUserId,
+        2,
+        2026,
+      );
+    });
+
+    it('should throw BadRequestException for invalid month (0)', async () => {
+      await expect(
+        controller.getBudgetVsActual(mockAuthenticatedRequest, 0, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for invalid month (13)', async () => {
+      await expect(
+        controller.getBudgetVsActual(mockAuthenticatedRequest, 13, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should use userId from authenticated request', async () => {
+      jest.spyOn(service, 'getBudgetVsActual').mockResolvedValue([]);
+
+      await controller.getBudgetVsActual(mockAuthenticatedRequest, 6, 2026);
+
+      expect(service.getBudgetVsActual).toHaveBeenCalledWith(
         mockUserId,
         6,
         2026,

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -10,6 +10,7 @@ import {
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import { DashboardService } from './dashboard.service';
+import { BudgetVsActualDto } from './dto/budget-vs-actual.dto';
 import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 
 @Controller('dashboard')
@@ -35,5 +36,18 @@ export class DashboardController {
 
     const userId = req.user.userId;
     return this.dashboardService.getMonthlySummary(userId, month, year);
+  }
+
+  @Get('budget-vs-actual')
+  @UseGuards(JwtAuthGuard)
+  async getBudgetVsActual(
+    @Req() req: AuthenticatedRequest,
+    @Query('month', ParseIntPipe) month: number,
+    @Query('year', ParseIntPipe) year: number,
+  ): Promise<BudgetVsActualDto[]> {
+    this.validateMonth(month);
+
+    const userId = req.user.userId;
+    return this.dashboardService.getBudgetVsActual(userId, month, year);
   }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { TransactionType } from '@prisma/client';
+import { CategoryType, TransactionType } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
+import { BudgetVsActualDto } from './dto/budget-vs-actual.dto';
 import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 
 @Injectable()
@@ -55,5 +56,123 @@ export class DashboardService {
       totalExpense,
       balance,
     };
+  }
+
+  async getBudgetVsActual(
+    userId: string,
+    month: number,
+    year: number,
+  ): Promise<BudgetVsActualDto[]> {
+    const { start, end } = this.getMonthRange(month, year);
+
+    const budgets = await this.prisma.budget.findMany({
+      where: {
+        userId,
+        month,
+        year,
+      },
+      select: {
+        amount: true,
+        categoryId: true,
+        category: {
+          select: {
+            id: true,
+            name: true,
+            type: true,
+          },
+        },
+      },
+    });
+
+    const transactions = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        date: {
+          gte: start,
+          lt: end,
+        },
+      },
+      select: {
+        amount: true,
+        categoryId: true,
+        category: {
+          select: {
+            id: true,
+            name: true,
+            type: true,
+          },
+        },
+      },
+    });
+
+    const actualByCategory = new Map<
+      string,
+      {
+        category: { id: string; name: string; type: CategoryType };
+        actualAmount: number;
+      }
+    >();
+
+    transactions.forEach((transaction) => {
+      const amount = Number(transaction.amount);
+      const existing = actualByCategory.get(transaction.categoryId);
+
+      if (existing) {
+        existing.actualAmount += amount;
+        return;
+      }
+
+      actualByCategory.set(transaction.categoryId, {
+        category: transaction.category,
+        actualAmount: amount,
+      });
+    });
+
+    const results: BudgetVsActualDto[] = [];
+    const budgetCategoryIds = new Set<string>();
+
+    budgets.forEach((budget) => {
+      const budgetAmount = Number(budget.amount);
+      const actualEntry = actualByCategory.get(budget.categoryId);
+      const actualAmount = actualEntry?.actualAmount ?? 0;
+      const difference = budgetAmount - actualAmount;
+      const percentageUsed =
+        budgetAmount === 0
+          ? actualAmount > 0
+            ? 100
+            : 0
+          : (actualAmount / budgetAmount) * 100;
+
+      results.push({
+        category: budget.category,
+        budgetAmount,
+        actualAmount,
+        difference,
+        percentageUsed,
+      });
+
+      budgetCategoryIds.add(budget.categoryId);
+    });
+
+    actualByCategory.forEach((entry, categoryId) => {
+      if (budgetCategoryIds.has(categoryId)) {
+        return;
+      }
+
+      const budgetAmount = 0;
+      const actualAmount = entry.actualAmount;
+      const difference = budgetAmount - actualAmount;
+      const percentageUsed = actualAmount > 0 ? 100 : 0;
+
+      results.push({
+        category: entry.category,
+        budgetAmount,
+        actualAmount,
+        difference,
+        percentageUsed,
+      });
+    });
+
+    return results;
   }
 }

--- a/src/modules/dashboard/dto/budget-vs-actual.dto.ts
+++ b/src/modules/dashboard/dto/budget-vs-actual.dto.ts
@@ -1,0 +1,15 @@
+import { CategoryType } from '@prisma/client';
+
+export class BudgetVsActualCategoryDto {
+  id: string;
+  name: string;
+  type: CategoryType;
+}
+
+export class BudgetVsActualDto {
+  category: BudgetVsActualCategoryDto;
+  budgetAmount: number;
+  actualAmount: number;
+  difference: number;
+  percentageUsed: number;
+}


### PR DESCRIPTION
- add GET /dashboard/budget-vs-actual with month/year validation
- implement service aggregation by category including no-budget categories
- add BudgetVsActual DTO for response shape
- add controller and service unit tests for budget vs actual