### PR TITLE
feat(dashboard): add top expenses endpoint with amount-based sorting

### DIFF
--- a/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/dashboard.controller.spec.ts
@@ -22,6 +22,7 @@ describe('DashboardController', () => {
       getMonthlySummary: jest.fn(),
       getBudgetVsActual: jest.fn(),
       getCategoryBreakdown: jest.fn(),
+      getTopExpenses: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -352,6 +353,211 @@ describe('DashboardController', () => {
         mockUserId,
         6,
         2026,
+      );
+    });
+  });
+
+  describe('getTopExpenses', () => {
+    it('should return top expenses for valid month and year with default limit', async () => {
+      const expectedResult = [
+        {
+          id: 'tx-1',
+          description: 'Rent',
+          date: '2026-03-01T00:00:00.000Z',
+          amount: 1500,
+          category: { id: 'cat-1', name: 'Housing', type: 'EXPENSE' },
+        },
+        {
+          id: 'tx-2',
+          description: 'Groceries',
+          date: '2026-03-15T00:00:00.000Z',
+          amount: 300,
+          category: { id: 'cat-2', name: 'Food', type: 'EXPENSE' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getTopExpenses')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        3,
+        2026,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        3,
+        2026,
+        10,
+      );
+    });
+
+    it('should return top expenses with custom limit', async () => {
+      const expectedResult = [
+        {
+          id: 'tx-1',
+          description: 'Rent',
+          date: '2026-03-01T00:00:00.000Z',
+          amount: 1500,
+          category: { id: 'cat-1', name: 'Housing', type: 'EXPENSE' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getTopExpenses')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        3,
+        2026,
+        5,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        3,
+        2026,
+        5,
+      );
+    });
+
+    it('should throw BadRequestException for invalid month (0)', async () => {
+      await expect(
+        controller.getTopExpenses(mockAuthenticatedRequest, 0, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for invalid month (13)', async () => {
+      await expect(
+        controller.getTopExpenses(mockAuthenticatedRequest, 13, 2026),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for invalid limit (0)', async () => {
+      await expect(
+        controller.getTopExpenses(mockAuthenticatedRequest, 6, 2026, 0),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for invalid limit (101)', async () => {
+      await expect(
+        controller.getTopExpenses(mockAuthenticatedRequest, 6, 2026, 101),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for negative limit', async () => {
+      await expect(
+        controller.getTopExpenses(mockAuthenticatedRequest, 6, 2026, -5),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should accept limit 1', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        6,
+        2026,
+        1,
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        6,
+        2026,
+        1,
+      );
+    });
+
+    it('should accept limit 100', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        6,
+        2026,
+        100,
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        6,
+        2026,
+        100,
+      );
+    });
+
+    it('should return empty array when no expenses exist', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        4,
+        2026,
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        4,
+        2026,
+        10,
+      );
+    });
+
+    it('should use userId from authenticated request', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      await controller.getTopExpenses(mockAuthenticatedRequest, 6, 2026, 10);
+
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        6,
+        2026,
+        10,
+      );
+    });
+
+    it('should accept month 1 (January)', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        1,
+        2026,
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        1,
+        2026,
+        10,
+      );
+    });
+
+    it('should accept month 12 (December)', async () => {
+      jest.spyOn(service, 'getTopExpenses').mockResolvedValue([]);
+
+      const result = await controller.getTopExpenses(
+        mockAuthenticatedRequest,
+        12,
+        2026,
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getTopExpenses).toHaveBeenCalledWith(
+        mockUserId,
+        12,
+        2026,
+        10,
       );
     });
   });

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -13,6 +13,7 @@ import { DashboardService } from './dashboard.service';
 import { BudgetVsActualDto } from './dto/budget-vs-actual.dto';
 import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 import { CategoryBreakdownDto } from './dto/category-breakdown.dto';
+import { TopExpenseDto } from './dto/top-expenses.dto';
 
 @Controller('dashboard')
 export class DashboardController {
@@ -22,6 +23,14 @@ export class DashboardController {
     if (month < 1 || month > 12) {
       throw new BadRequestException(
         'Invalid month. Month must be between 1 and 12.',
+      );
+    }
+  }
+
+  private validateLimit(limit: number): void {
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException(
+        'Invalid limit. Limit must be between 1 and 100.',
       );
     }
   }
@@ -63,5 +72,28 @@ export class DashboardController {
 
     const userId = req.user.userId;
     return this.dashboardService.getCategoryBreakdown(userId, month, year);
+  }
+
+  @Get('top-expenses')
+  @UseGuards(JwtAuthGuard)
+  async getTopExpenses(
+    @Req() req: AuthenticatedRequest,
+    @Query('month', ParseIntPipe) month: number,
+    @Query('year', ParseIntPipe) year: number,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ): Promise<TopExpenseDto[]> {
+    this.validateMonth(month);
+
+    if (limit !== undefined) {
+      this.validateLimit(limit);
+    }
+
+    const userId = req.user.userId;
+    return this.dashboardService.getTopExpenses(
+      userId,
+      month,
+      year,
+      limit ?? 10,
+    );
   }
 }

--- a/src/modules/dashboard/dashboard.service.spec.ts
+++ b/src/modules/dashboard/dashboard.service.spec.ts
@@ -507,4 +507,274 @@ describe('DashboardService', () => {
       expect(callArgs.where.userId).toBe(differentUserId);
     });
   });
+
+  describe('getTopExpenses', () => {
+    it('should return top expenses sorted by amount descending then date descending', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: 'Rent',
+          date: new Date('2026-03-01'),
+          amount: 1500,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Housing',
+            type: CategoryType.EXPENSE,
+          },
+        },
+        {
+          id: 'tx-2',
+          description: 'Groceries',
+          date: new Date('2026-03-15'),
+          amount: 300,
+          categoryId: 'cat-2',
+          category: { id: 'cat-2', name: 'Food', type: CategoryType.EXPENSE },
+        },
+        {
+          id: 'tx-3',
+          description: 'Dining',
+          date: new Date('2026-03-20'),
+          amount: 200,
+          categoryId: 'cat-2',
+          category: { id: 'cat-2', name: 'Food', type: CategoryType.EXPENSE },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getTopExpenses(mockUserId, 3, 2026, 10);
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        id: 'tx-1',
+        description: 'Rent',
+        date: '2026-03-01T00:00:00.000Z',
+        amount: 1500,
+        category: { id: 'cat-1', name: 'Housing', type: CategoryType.EXPENSE },
+      });
+      expect(result[1]).toEqual({
+        id: 'tx-2',
+        description: 'Groceries',
+        date: '2026-03-15T00:00:00.000Z',
+        amount: 300,
+        category: { id: 'cat-2', name: 'Food', type: CategoryType.EXPENSE },
+      });
+    });
+
+    it('should return empty array when no transactions exist', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      const result = await service.getTopExpenses(mockUserId, 4, 2026, 10);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should apply limit correctly', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: 'Item 1',
+          date: new Date('2026-05-01'),
+          amount: 500,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Shopping',
+            type: CategoryType.EXPENSE,
+          },
+        },
+        {
+          id: 'tx-2',
+          description: 'Item 2',
+          date: new Date('2026-05-02'),
+          amount: 400,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Shopping',
+            type: CategoryType.EXPENSE,
+          },
+        },
+        {
+          id: 'tx-3',
+          description: 'Item 3',
+          date: new Date('2026-05-03'),
+          amount: 300,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Shopping',
+            type: CategoryType.EXPENSE,
+          },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getTopExpenses(mockUserId, 5, 2026, 2);
+
+      expect(result).toHaveLength(3); // Mock returns all, Prisma handles limit
+      expect(prismaService.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 2,
+        }),
+      );
+    });
+
+    it('should filter only EXPENSE transactions', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      await service.getTopExpenses(mockUserId, 6, 2026, 10);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.where.type).toBe(TransactionType.EXPENSE);
+    });
+
+    it('should filter by month and year range', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      await service.getTopExpenses(mockUserId, 7, 2026, 10);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.where.date.gte).toEqual(
+        new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0)),
+      );
+      expect(callArgs.where.date.lt).toEqual(
+        new Date(Date.UTC(2026, 7, 1, 0, 0, 0, 0)),
+      );
+    });
+
+    it('should ensure user isolation by filtering on userId', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      const differentUserId = 'user-456';
+      await service.getTopExpenses(differentUserId, 8, 2026, 10);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.where.userId).toBe(differentUserId);
+    });
+
+    it('should convert Decimal amounts to numbers', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: 'Test',
+          date: new Date('2026-09-01'),
+          amount: 250,
+          categoryId: 'cat-1',
+          category: { id: 'cat-1', name: 'Test', type: CategoryType.EXPENSE },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getTopExpenses(mockUserId, 9, 2026, 10);
+
+      expect(result[0].amount).toBe(250);
+      expect(typeof result[0].amount).toBe('number');
+    });
+
+    it('should convert ISO date strings correctly', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: 'Test',
+          date: new Date('2026-10-15'),
+          amount: 100,
+          categoryId: 'cat-1',
+          category: { id: 'cat-1', name: 'Test', type: CategoryType.EXPENSE },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getTopExpenses(mockUserId, 10, 2026, 10);
+
+      expect(result[0].date).toBe('2026-10-15T00:00:00.000Z');
+    });
+
+    it('should handle null description field', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: null,
+          date: new Date('2026-11-01'),
+          amount: 50,
+          categoryId: 'cat-1',
+          category: { id: 'cat-1', name: 'Test', type: CategoryType.EXPENSE },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      const result = await service.getTopExpenses(mockUserId, 11, 2026, 10);
+
+      expect(result[0].description).toBeNull();
+    });
+
+    it('should sort by date descending as secondary sort for same amount', async () => {
+      const transactions = [
+        {
+          id: 'tx-1',
+          description: 'First',
+          date: new Date('2026-12-05'),
+          amount: 500,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Category',
+            type: CategoryType.EXPENSE,
+          },
+        },
+        {
+          id: 'tx-2',
+          description: 'Second',
+          date: new Date('2026-12-10'),
+          amount: 500,
+          categoryId: 'cat-1',
+          category: {
+            id: 'cat-1',
+            name: 'Category',
+            type: CategoryType.EXPENSE,
+          },
+        },
+      ];
+
+      jest
+        .spyOn(prismaService.transaction, 'findMany')
+        .mockResolvedValue(transactions as any);
+
+      await service.getTopExpenses(mockUserId, 12, 2026, 10);
+
+      expect(prismaService.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ amount: 'desc' }, { date: 'desc' }],
+        }),
+      );
+    });
+
+    it('should use default limit of 10 when not provided', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+
+      await service.getTopExpenses(mockUserId, 1, 2026);
+
+      const callArgs = (prismaService.transaction.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.take).toBe(10);
+    });
+  });
 });

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../shared/prisma.service';
 import { BudgetVsActualDto } from './dto/budget-vs-actual.dto';
 import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 import { CategoryBreakdownDto } from './dto/category-breakdown.dto';
+import { TopExpenseDto } from './dto/top-expenses.dto';
 
 @Injectable()
 export class DashboardService {
@@ -248,5 +249,48 @@ export class DashboardService {
     });
 
     return results;
+  }
+
+  async getTopExpenses(
+    userId: string,
+    month: number,
+    year: number,
+    limit: number = 10,
+  ): Promise<TopExpenseDto[]> {
+    const { start, end } = this.getMonthRange(month, year);
+
+    const transactions = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        type: TransactionType.EXPENSE,
+        date: {
+          gte: start,
+          lt: end,
+        },
+      },
+      select: {
+        id: true,
+        description: true,
+        date: true,
+        amount: true,
+        category: {
+          select: {
+            id: true,
+            name: true,
+            type: true,
+          },
+        },
+      },
+      orderBy: [{ amount: 'desc' }, { date: 'desc' }],
+      take: limit,
+    });
+
+    return transactions.map((transaction) => ({
+      id: transaction.id,
+      description: transaction.description,
+      date: transaction.date.toISOString(),
+      amount: Number(transaction.amount),
+      category: transaction.category,
+    }));
   }
 }

--- a/src/modules/dashboard/dto/top-expenses.dto.ts
+++ b/src/modules/dashboard/dto/top-expenses.dto.ts
@@ -1,0 +1,15 @@
+import { CategoryType } from '@prisma/client';
+
+export class TopExpenseCategoryDto {
+  id: string;
+  name: string;
+  type: CategoryType;
+}
+
+export class TopExpenseDto {
+  id: string;
+  description: string | null;
+  date: string;
+  amount: number;
+  category: TopExpenseCategoryDto;
+}


### PR DESCRIPTION
- Add GET /dashboard/top-expenses endpoint to retrieve highest expenses for a given month/year
- Filter transactions by month and year with proper date range handling
- Sort expenses by amount descending, then by date descending for stable ordering
- Implement optional limit parameter (1-100, default 10) to control result size
- Create TopExpenseDto and TopExpenseCategoryDto response DTOs
- Add getTopExpenses() service method with Prisma findMany query
- Convert Decimal amounts to numbers and dates to ISO strings in response
- Add validateLimit() helper method with BadRequestException for invalid limits
- Return empty array when no expenses exist for the requested month
- Add JwtAuthGuard protection to endpoint with month validation (1-12)
- Add 12 controller tests covering validation, limit boundaries, and empty results
- Add 11 service tests covering sorting, filtering, limit enforcement, and data conversion