### PR TITLE
docs(categories): add Swagger/OpenAPI documentation to Categories API

### DIFF
--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -9,23 +9,62 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryDto } from './dto/category.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
+@ApiTags('categories')
 @Controller('categories')
 @UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get all categories' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all categories for the authenticated user',
+    type: [CategoryDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
   getAllCategories(@Request() req: AuthenticatedRequest) {
     return this.categoriesService.getAllCategories(req.user.userId);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a specific category by ID' })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the category to retrieve',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Category found and returned successfully',
+    type: CategoryDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Category not found',
+  })
   getCategoryById(
     @Param('id') id: string,
     @Request() req: AuthenticatedRequest,
@@ -34,6 +73,20 @@ export class CategoriesController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create a new category' })
+  @ApiResponse({
+    status: 201,
+    description: 'Category created successfully',
+    type: CategoryDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid input data',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
   createCategory(
     @Body() createCategoryDto: CreateCategoryDto,
     @Request() req: AuthenticatedRequest,
@@ -45,6 +98,29 @@ export class CategoriesController {
   }
 
   @Put(':id')
+  @ApiOperation({ summary: 'Update an existing category' })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the category to update',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Category updated successfully',
+    type: CategoryDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid input data',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Category not found',
+  })
   updateCategory(
     @Param('id') id: string,
     @Body() updateCategoryDto: UpdateCategoryDto,
@@ -58,6 +134,24 @@ export class CategoriesController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a category' })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the category to delete',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Category deleted successfully',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Category not found',
+  })
   deleteCategory(
     @Param('id') id: string,
     @Request() req: AuthenticatedRequest,

--- a/src/modules/categories/dto/category.dto.ts
+++ b/src/modules/categories/dto/category.dto.ts
@@ -1,8 +1,14 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CategoryDto {
+  @ApiProperty({ description: 'The name of the category' })
   @IsString()
   name: string;
+
+  @ApiProperty({
+    description: 'The type of the category (e.g., expense, income)',
+  })
   @IsString()
   type: string;
 }

--- a/src/modules/categories/dto/create-category.dto.ts
+++ b/src/modules/categories/dto/create-category.dto.ts
@@ -1,8 +1,14 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCategoryDto {
+  @ApiProperty({ description: 'The name of the category' })
   @IsString()
   name: string;
+
+  @ApiProperty({
+    description: 'The type of the category (e.g., expense, income)',
+  })
   @IsString()
   type: string;
 }

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,12 +1,18 @@
 import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateCategoryDto {
   //   @IsNumber()
   //   id: number;
+  @ApiProperty({ description: 'The name of the category', required: false })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiProperty({
+    description: 'The type of the category (e.g., expense, income)',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   type?: string;


### PR DESCRIPTION
- Add Swagger decorators to CategoriesController
  * @ApiTags('categories') for API grouping
  * @ApiBearerAuth() for JWT authentication requirement
  * @ApiOperation() for endpoint descriptions
  * @ApiResponse() for all status codes (200, 201, 400, 401, 404)
  * @ApiParam() for path parameters

- Add Swagger decorators to Category DTOs
  * CategoryDto: Add @ApiProperty() to name and type fields
  * CreateCategoryDto: Add @ApiProperty() to name and type fields
  * UpdateCategoryDto: Add @ApiProperty() with required: false for optional fields

- Document all CRUD endpoints
  * GET /categories - List all user categories
  * GET /categories/:id - Get category by ID
  * POST /categories - Create new category
  * PUT /categories/:id - Update existing category
  * DELETE /categories/:id - Delete category