### PR TITLE
docs: add Swagger documentation to transaction endpoints

### DIFF
--- a/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/src/modules/transactions/dto/create-transaction.dto.ts
@@ -6,21 +6,44 @@ import {
   IsString,
   IsUUID,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateTransactionDto {
+  @ApiProperty({
+    description: 'Transaction amount (must be positive)',
+    example: 99.99,
+    minimum: 0.01,
+  })
   @IsNumber()
   @IsPositive()
   amount: number;
 
+  @ApiProperty({
+    description: 'Transaction type',
+    example: 'EXPENSE',
+  })
   @IsString()
   type: string;
 
+  @ApiProperty({
+    description: 'Category UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   categoryId: string;
 
+  @ApiProperty({
+    description: 'Transaction date in ISO 8601 format',
+    example: '2026-02-26T10:00:00.000Z',
+  })
   @IsDateString()
   date: string;
 
+  @ApiProperty({
+    description: 'Optional description of the transaction',
+    example: 'Grocery shopping at Walmart',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   description?: string;

--- a/src/modules/transactions/dto/transaction.dto.ts
+++ b/src/modules/transactions/dto/transaction.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TransactionDto {
+  @ApiProperty({
+    description: 'The unique identifier of the transaction',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Transaction amount (must be positive)',
+    example: 99.99,
+  })
+  amount: number;
+
+  @ApiProperty({
+    description: 'Transaction type',
+    example: 'EXPENSE',
+  })
+  type: string;
+
+  @ApiProperty({
+    description: 'Category UUID',
+    example: '123e4567-e89b-12d3-a456-426614174001',
+  })
+  categoryId: string;
+
+  @ApiProperty({
+    description: 'Transaction date in ISO 8601 format',
+    example: '2026-02-26T10:00:00.000Z',
+  })
+  date: string;
+
+  @ApiProperty({
+    description: 'Optional description of the transaction',
+    example: 'Grocery shopping at Walmart',
+    required: false,
+  })
+  description?: string;
+
+  @ApiProperty({
+    description: 'User ID who owns the transaction',
+    example: '123e4567-e89b-12d3-a456-426614174002',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: 'Timestamp when the transaction was created',
+    example: '2026-02-26T10:00:00.000Z',
+  })
+  createdAt: string;
+
+  @ApiProperty({
+    description: 'Timestamp when the transaction was last updated',
+    example: '2026-02-26T10:00:00.000Z',
+  })
+  updatedAt: string;
+}

--- a/src/modules/transactions/dto/update-transaction.dto.ts
+++ b/src/modules/transactions/dto/update-transaction.dto.ts
@@ -5,24 +5,50 @@ import {
   IsString,
   IsUUID,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateTransactionDto {
+  @ApiProperty({
+    description: 'Transaction amount (must be positive)',
+    example: 99.99,
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   amount?: number;
 
+  @ApiProperty({
+    description: 'Transaction type',
+    example: 'EXPENSE',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   type?: string;
 
+  @ApiProperty({
+    description: 'Category UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
   @IsOptional()
   @IsUUID()
   categoryId?: string;
 
+  @ApiProperty({
+    description: 'Transaction date in ISO 8601 format',
+    example: '2026-02-26T10:00:00.000Z',
+    required: false,
+  })
   @IsOptional()
   @IsDateString()
   date?: string;
 
+  @ApiProperty({
+    description: 'Optional description of the transaction',
+    example: 'Grocery shopping at Walmart',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   description?: string;

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -10,23 +10,62 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { TransactionsService } from './transactions.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { TransactionDto } from './dto/transaction.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
+@ApiTags('transactions')
 @Controller('transactions')
 @UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 export class TransactionController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get all transactions' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all transactions for the authenticated user',
+    type: [TransactionDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
   async getAllTransactions(@Request() req: AuthenticatedRequest) {
     return this.transactionsService.getAllTransactions(req.user.userId);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a specific transaction by ID' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the transaction to retrieve',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Transaction found and returned successfully',
+    type: TransactionDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Transaction not found',
+  })
   async getTransactionById(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Request() req: AuthenticatedRequest,
@@ -35,6 +74,20 @@ export class TransactionController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create a new transaction' })
+  @ApiResponse({
+    status: 201,
+    description: 'Transaction created successfully',
+    type: TransactionDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid input data',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
   async createTransaction(
     @Body() createTransactionDto: CreateTransactionDto,
     @Request() req: AuthenticatedRequest,
@@ -46,6 +99,29 @@ export class TransactionController {
   }
 
   @Put(':id')
+  @ApiOperation({ summary: 'Update an existing transaction' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the transaction to update',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Transaction updated successfully',
+    type: TransactionDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid input data',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Transaction not found',
+  })
   async updateTransaction(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateTransactionDto: UpdateTransactionDto,
@@ -59,6 +135,24 @@ export class TransactionController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a transaction' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the transaction to delete',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Transaction deleted successfully',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Transaction not found',
+  })
   async deleteTransaction(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Request() req: AuthenticatedRequest,


### PR DESCRIPTION
Add comprehensive OpenAPI/Swagger documentation to the transactions module:

- Add @ApiTags and @ApiBearerAuth decorators to controller
- Document all 5 endpoints (GET all, GET by id, POST, PUT, DELETE) with @ApiOperation
- Add @ApiResponse decorators for status codes: 200, 201, 400, 401, 404
- Add @ApiParam decorators for UUID path parameters
- Create TransactionDto with @ApiProperty for response schema
- Add @ApiProperty decorators to CreateTransactionDto with descriptions, examples, and constraints
- Add @ApiProperty decorators to UpdateTransactionDto with required: false for optional fields

All endpoints now display properly in Swagger UI at /docs with clear descriptions, request/response schemas, and authentication requirements.