### PR TITLE
docs: add Swagger documentation to budget endpoints

### DIFF
--- a/src/modules/budgets/budget.controller.ts
+++ b/src/modules/budgets/budget.controller.ts
@@ -10,23 +10,63 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { BudgetService } from './budget.service';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
+import { BudgetDto } from './dto/budget.dto';
+import { BudgetWithSpendingDto } from './dto/budget-with-spending.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
+@ApiTags('budgets')
 @Controller('budgets')
 @UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 export class BudgetController {
   constructor(private readonly budgetService: BudgetService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get all budgets' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all budgets for the authenticated user',
+    type: [BudgetDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
   async getAllBudgets(@Request() req: AuthenticatedRequest) {
     return this.budgetService.getAllBudgets(req.user.userId);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a specific budget by ID' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the budget to retrieve',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Budget found and returned successfully',
+    type: BudgetDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Budget not found',
+  })
   async getBudgetById(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Request() req: AuthenticatedRequest,
@@ -35,6 +75,29 @@ export class BudgetController {
   }
 
   @Get(':id/details')
+  @ApiOperation({
+    summary: 'Get budget with spending details',
+    description:
+      'Returns a budget with calculated spending data including spent amount, remaining amount, and utilization percentage',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the budget to retrieve with spending details',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Budget with spending calculations returned successfully',
+    type: BudgetWithSpendingDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Budget not found',
+  })
   async getBudgetsWithTransactions(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Request() req: AuthenticatedRequest,
@@ -43,6 +106,25 @@ export class BudgetController {
   }
 
   @Get('category/:categoryId')
+  @ApiOperation({ summary: 'Get budgets by category' })
+  @ApiParam({
+    name: 'categoryId',
+    description: 'The UUID of the category to filter budgets by',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of budgets for the specified category',
+    type: [BudgetDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Category not found',
+  })
   getBudgetsByCategory(
     @Param('categoryId', new ParseUUIDPipe()) categoryId: string,
     @Request() req: AuthenticatedRequest,
@@ -51,6 +133,26 @@ export class BudgetController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create a new budget' })
+  @ApiResponse({
+    status: 201,
+    description: 'Budget created successfully',
+    type: BudgetDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Bad request - Invalid input data (e.g., month not in range 1-12)',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 409,
+    description:
+      'Conflict - Budget already exists for this category, month, and year',
+  })
   async createBudget(
     @Body() budgetData: CreateBudgetDto,
     @Request() req: AuthenticatedRequest,
@@ -59,6 +161,34 @@ export class BudgetController {
   }
 
   @Put(':id')
+  @ApiOperation({ summary: 'Update an existing budget' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the budget to update',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Budget updated successfully',
+    type: BudgetDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid input data',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Budget not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description:
+      'Conflict - Budget already exists for this category, month, and year',
+  })
   async updateBudget(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body()
@@ -69,6 +199,24 @@ export class BudgetController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a budget' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the budget to delete',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Budget deleted successfully',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing JWT token',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Budget not found',
+  })
   async deleteBudget(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Request() req: AuthenticatedRequest,

--- a/src/modules/budgets/dto/budget-with-spending.dto.ts
+++ b/src/modules/budgets/dto/budget-with-spending.dto.ts
@@ -1,21 +1,23 @@
-import { IsEnum, IsNumber, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { BudgetType } from '@prisma/client';
 
-export class CreateBudgetDto {
+export class BudgetWithSpendingDto {
+  @ApiProperty({
+    description: 'The unique identifier of the budget',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
   @ApiProperty({
     description: 'Budget amount (must be positive)',
     example: 500.0,
-    minimum: 0.01,
   })
-  @IsNumber()
   amount: number;
 
   @ApiProperty({
     description: 'Category UUID',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: '123e4567-e89b-12d3-a456-426614174001',
   })
-  @IsUUID()
   categoryId: string;
 
   @ApiProperty({
@@ -24,14 +26,12 @@ export class CreateBudgetDto {
     minimum: 1,
     maximum: 12,
   })
-  @IsNumber()
   month: number;
 
   @ApiProperty({
     description: 'Year of the budget',
     example: 2026,
   })
-  @IsNumber()
   year: number;
 
   @ApiProperty({
@@ -39,6 +39,23 @@ export class CreateBudgetDto {
     enum: BudgetType,
     example: BudgetType.EXPENSE,
   })
-  @IsEnum(BudgetType)
   type: BudgetType;
+
+  @ApiProperty({
+    description: 'Total amount spent in this budget period',
+    example: 350.5,
+  })
+  spent: number;
+
+  @ApiProperty({
+    description: 'Remaining amount in the budget',
+    example: 149.5,
+  })
+  remaining: number;
+
+  @ApiProperty({
+    description: 'Percentage of budget utilized',
+    example: 70.1,
+  })
+  utilizationPercentage: number;
 }

--- a/src/modules/budgets/dto/budget.dto.ts
+++ b/src/modules/budgets/dto/budget.dto.ts
@@ -1,21 +1,23 @@
-import { IsEnum, IsNumber, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { BudgetType } from '@prisma/client';
 
-export class CreateBudgetDto {
+export class BudgetDto {
+  @ApiProperty({
+    description: 'The unique identifier of the budget',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
   @ApiProperty({
     description: 'Budget amount (must be positive)',
     example: 500.0,
-    minimum: 0.01,
   })
-  @IsNumber()
   amount: number;
 
   @ApiProperty({
     description: 'Category UUID',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: '123e4567-e89b-12d3-a456-426614174001',
   })
-  @IsUUID()
   categoryId: string;
 
   @ApiProperty({
@@ -24,14 +26,12 @@ export class CreateBudgetDto {
     minimum: 1,
     maximum: 12,
   })
-  @IsNumber()
   month: number;
 
   @ApiProperty({
     description: 'Year of the budget',
     example: 2026,
   })
-  @IsNumber()
   year: number;
 
   @ApiProperty({
@@ -39,6 +39,11 @@ export class CreateBudgetDto {
     enum: BudgetType,
     example: BudgetType.EXPENSE,
   })
-  @IsEnum(BudgetType)
   type: BudgetType;
+
+  @ApiProperty({
+    description: 'User ID who owns the budget',
+    example: '123e4567-e89b-12d3-a456-426614174002',
+  })
+  userId: string;
 }

--- a/src/modules/budgets/dto/update-budget.dto.ts
+++ b/src/modules/budgets/dto/update-budget.dto.ts
@@ -1,23 +1,52 @@
 import { IsEnum, IsNumber, IsOptional, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { BudgetType } from '@prisma/client';
 
 export class UpdateBudgetDto {
+  @ApiProperty({
+    description: 'Budget amount (must be positive)',
+    example: 500.0,
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   amount?: number;
 
+  @ApiProperty({
+    description: 'Category UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
   @IsOptional()
   @IsUUID()
   categoryId?: string;
 
+  @ApiProperty({
+    description: 'Month of the budget (1-12)',
+    example: 3,
+    minimum: 1,
+    maximum: 12,
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   month?: number;
 
+  @ApiProperty({
+    description: 'Year of the budget',
+    example: 2026,
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   year?: number;
 
+  @ApiProperty({
+    description: 'Budget type',
+    enum: BudgetType,
+    example: BudgetType.EXPENSE,
+    required: false,
+  })
   @IsOptional()
   @IsEnum(BudgetType)
   type?: BudgetType;


### PR DESCRIPTION
Add comprehensive OpenAPI/Swagger documentation to the budgets module:

- Add @ApiTags and @ApiBearerAuth decorators to controller
- Document all 7 endpoints (GET all, GET by id, GET details, GET by category, POST, PUT, DELETE) with @ApiOperation
- Add @ApiResponse decorators for status codes: 200, 201, 400, 401, 404, 409
- Add @ApiParam decorators for UUID path parameters (id and categoryId)
- Create BudgetDto with @ApiProperty for basic budget response schema
- Create BudgetWithSpendingDto with spending calculations (spent, remaining, utilizationPercentage)
- Add @ApiProperty decorators to CreateBudgetDto with descriptions, examples, enum values, and constraints
- Add @ApiProperty decorators to UpdateBudgetDto with required: false for optional fields
- Document BudgetType enum (EXPENSE, INCOME) with visible values in Swagger
- Document month validation range (1-12) and positive amount constraints
- Document 409 Conflict response for duplicate budget scenarios