### PR TITLE
feat(docker): add multi-stage Docker setup for NestJS app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+node_modules
+dist
+coverage
+npm-debug.log
+Dockerfile*
+docker-compose*.yml
+.env
+.env.*
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM node:22-slim AS dependencies
+
+WORKDIR /app
+
+RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm ci
+
+COPY prisma ./prisma
+RUN npx prisma generate
+
+
+FROM dependencies AS build
+
+COPY tsconfig*.json ./
+COPY nest-cli.json ./
+COPY src ./src
+RUN npm run build
+
+
+FROM dependencies AS development
+
+COPY tsconfig*.json ./
+COPY nest-cli.json ./
+COPY src ./src
+
+EXPOSE 3000
+CMD ["npm", "run", "start:dev"]
+
+
+FROM node:22-slim AS production
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+COPY --from=dependencies /app/node_modules ./node_modules
+RUN npm prune --omit=dev
+
+COPY --from=build /app/dist ./dist
+COPY prisma ./prisma
+
+EXPOSE 3000
+CMD ["npm", "run", "start:prod"]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,44 @@ The server will start on `http://localhost:3000`.
 
 ---
 
+## 🐳 Docker
+
+This project includes a multi-stage Docker setup with two targets:
+
+- **production**: optimized image running `npm run start:prod`
+- **development**: image for local development running `npm run start:dev`
+
+### Build Images
+
+```bash
+# Production image
+docker build -t my-pocket-backend:prod --target production .
+
+# Development image
+docker build -t my-pocket-backend:dev --target development .
+```
+
+### Run Containers
+
+```bash
+# Production container
+docker run --rm -p 3000:3000 --env-file .env my-pocket-backend:prod
+
+# Development container
+docker run --rm -p 3000:3000 --env-file .env my-pocket-backend:dev
+```
+
+Required environment variables (see `.env.example`):
+
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `JWT_EXPIRATION`
+- `PORT` (optional, defaults to 3000)
+
+> Note: Database provisioning/migrations are intentionally outside this Docker scope.
+
+---
+
 ## 📚 API Documentation
 
 Once the server is running, visit the **interactive Swagger documentation**:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",


### PR DESCRIPTION
- add `.dockerignore` to reduce build context and avoid leaking local/env files
- add multi-stage `Dockerfile` with:
  - `dependencies` stage (`npm ci` + `prisma generate`)
  - `build` stage (`npm run build`)
  - `development` target (`npm run start:dev`)
  - `production` target with pruned deps and `npm run start:prod`
- update `package.json` production entrypoint to `node dist/src/main.js`
- document Docker build/run workflow and required env vars in `README.md`
- note DB provisioning/migrations remain out of Docker scope