### PR TITLE
feat: add Docker Compose setup for local development

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,15 @@
+# Docker Compose Environment Configuration
+# Copy this file and configure as needed for local docker-compose development
+
+# Database Connection
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/bd_my_pocket
+
+# Node Environment
+NODE_ENV=production
+
+# JWT Configuration
+JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_EXPIRATION=3600
+
+# Application Port
+PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-slim AS dependencies
 
 WORKDIR /app
 
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y openssl postgresql-client && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
 RUN npm ci
@@ -34,7 +34,7 @@ FROM node:22-slim AS production
 WORKDIR /app
 ENV NODE_ENV=production
 
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y openssl postgresql-client && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
 COPY --from=dependencies /app/node_modules ./node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  # PostgreSQL for Development
+  postgres:
+    image: postgres:16-alpine
+    container_name: my-pocket-postgres-dev
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: bd_my_pocket
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - my-pocket-network
+
+  # PostgreSQL for Testing
+  postgres-test:
+    image: postgres:16-alpine
+    container_name: my-pocket-postgres-test
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: bd_my_pocket_test
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - my-pocket-network
+
+  # NestJS Application
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    container_name: my-pocket-backend
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/bd_my_pocket
+      NODE_ENV: production
+      JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-key-change-this-in-production}
+      JWT_EXPIRATION: 3600
+      PORT: 3000
+    ports:
+      - '3000:3000'
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./scripts/docker-entrypoint.sh:/app/docker-entrypoint.sh
+    entrypoint: /bin/sh /app/docker-entrypoint.sh
+    networks:
+      - my-pocket-network
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+    driver: local
+
+networks:
+  my-pocket-network:
+    driver: bridge

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for services to be ready..."
+sleep 10
+
+echo "Running database migrations..."
+npm run db:migrate:deploy
+
+echo "Attempting to seed database..."
+npm run db:seed || echo "Warning: Seeding failed, but continuing with app startup"
+
+echo "Starting NestJS application..."
+exec npm run start:prod


### PR DESCRIPTION
Add comprehensive Docker Compose configuration to simplify local development and testing workflows:

- Add .env.docker with default environment variables for Docker setup
- Update Dockerfile to install postgresql-client for database operations
- Add docker-compose.yml with three services:
  - postgres: PostgreSQL 16 for development (port 5432)
  - postgres-test: PostgreSQL 16 for testing (port 5433)
  - app: NestJS application with automatic migrations and seeding
- Add docker-entrypoint.sh script to handle:
  - Service startup coordination
  - Database migration deployment
  - Database seeding with error handling
  - NestJS application startup