### PR TITLE
feat: centralize env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,16 @@
-# Database
-DATABASE_URL="postgresql://user:password@localhost:5432/my_pocket_db?schema=public"
+#############################################
+# Copy this file to `.env` and customize it #
+#############################################
 
-# Application
+# Runtime
+NODE_ENV=development
 PORT=3000
 
+# Database (PostgreSQL connection string)
+DATABASE_URL="postgresql://user:password@localhost:5432/my_pocket_db?schema=public"
+
 # JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+# Use a strong, unique secret with at least 32 characters
+JWT_SECRET=change-me-to-a-long-random-string-with-at-least-32-characters
+# Expiration in seconds (3600 = 1 hour)
 JWT_EXPIRATION=3600

--- a/README.md
+++ b/README.md
@@ -52,16 +52,19 @@ Before you begin, ensure you have the following installed:
 Create a `.env` file in the root directory (you can copy from `.env.example`):
 
 ```env
+# Runtime
+NODE_ENV=development
+PORT=3000
+
 # Database Connection (PostgreSQL)
 DATABASE_URL="postgresql://user:password@localhost:5432/my_pocket_db?schema=public"
 
-# Application Port (optional, defaults to 3000)
-PORT=3000
-
-# JWT Authentication
+# JWT Authentication (secret must be >= 32 chars)
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
 JWT_EXPIRATION=3600  # Token expiration in seconds (3600 = 1 hour)
 ```
+
+> The ConfigModule validates these variables at startup, so the app fails fast when something is missing or misconfigured.
 
 ### Testing Environment
 
@@ -110,7 +113,7 @@ cp .env.example .env
 
 # Edit .env with your database credentials
 # Update DATABASE_URL with your PostgreSQL user/password
-# Set a strong JWT_SECRET
+# Set a strong JWT_SECRET (minimum 32 characters)
 ```
 
 ### 4. Run Database Migrations
@@ -176,9 +179,10 @@ docker run --rm -p 3000:3000 --env-file .env my-pocket-backend:dev
 Required environment variables (see `.env.example`):
 
 - `DATABASE_URL`
-- `JWT_SECRET`
+- `JWT_SECRET` (minimum 32 characters)
 - `JWT_EXPIRATION`
 - `PORT` (optional, defaults to 3000)
+- `NODE_ENV` (optional, defaults to `development`)
 
 > Note: Database provisioning/migrations are intentionally outside this Docker scope.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "bcryptjs": "^3.0.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "joi": "^17.13.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
@@ -886,6 +887,19 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2429,6 +2443,24 @@
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -6666,6 +6698,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bcryptjs": "^3.0.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "joi": "^17.13.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { configurations, envValidationSchema } from './modules/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from './modules/health/health.module';
@@ -10,11 +11,24 @@ import { AuthsModule } from './modules/auths/auths.module';
 import { SharedModule } from './modules/shared';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 
+const envFileMap: Record<string, string> = {
+  test: '.env.test',
+  docker: '.env.docker',
+};
+
+const resolveEnvFilePath = () =>
+  envFileMap[process.env.NODE_ENV ?? ''] ?? '.env';
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
+      envFilePath: resolveEnvFilePath(),
+      load: configurations,
+      validationSchema: envValidationSchema,
+      validationOptions: {
+        abortEarly: false,
+      },
     }),
     SharedModule,
     HealthModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
@@ -27,6 +28,8 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
 
-  await app.listen(process.env.PORT ?? 3000);
+  const configService = app.get(ConfigService);
+  const port = configService.getOrThrow<number>('app.server.port');
+  await app.listen(port);
 }
 bootstrap();

--- a/src/modules/auths/auths.module.ts
+++ b/src/modules/auths/auths.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { JwtModule, JwtService } from '@nestjs/jwt';
+import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthsService } from './auths.service';
@@ -16,23 +16,15 @@ import { JwtAuthGuard } from './jwt-auth.guard';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const secret = configService.get<string>('JWT_SECRET');
-        const expiresIn = configService.get<number>('JWT_EXPIRATION');
-
-        if (!secret) {
-          throw new Error('JWT_SECRET is not defined in environment variables');
-        }
-
-        if (!expiresIn) {
-          throw new Error(
-            'JWT_EXPIRATION is not defined in environment variables',
-          );
-        }
+        const secret = configService.getOrThrow<string>('jwt.secret');
+        const expiresIn = configService.getOrThrow<number>(
+          'jwt.expiresInSeconds',
+        );
 
         return {
           secret,
           signOptions: {
-            expiresIn: `${expiresIn}s`,
+            expiresIn,
           },
         };
       },

--- a/src/modules/auths/jwt.strategy.ts
+++ b/src/modules/auths/jwt.strategy.ts
@@ -15,16 +15,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
     private prismaService: PrismaService,
   ) {
-    const secret = configService.get<string>('JWT_SECRET');
-
-    if (!secret) {
-      throw new Error('JWT_SECRET is not defined in environment variables');
-    }
-
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: secret,
+      secretOrKey: configService.getOrThrow<string>('jwt.secret'),
     });
   }
 

--- a/src/modules/config/configuration.ts
+++ b/src/modules/config/configuration.ts
@@ -1,0 +1,24 @@
+import { registerAs } from '@nestjs/config';
+
+const parseNumber = (value: string | undefined, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const appConfig = registerAs('app', () => ({
+  nodeEnv: process.env.NODE_ENV ?? 'development',
+  server: {
+    port: parseNumber(process.env.PORT, 3000),
+  },
+}));
+
+export const databaseConfig = registerAs('database', () => ({
+  url: process.env.DATABASE_URL,
+}));
+
+export const jwtConfig = registerAs('jwt', () => ({
+  secret: process.env.JWT_SECRET,
+  expiresInSeconds: parseNumber(process.env.JWT_EXPIRATION, 3600),
+}));
+
+export const configurations = [appConfig, databaseConfig, jwtConfig];

--- a/src/modules/config/env.validation.ts
+++ b/src/modules/config/env.validation.ts
@@ -1,0 +1,13 @@
+import * as Joi from 'joi';
+
+export const envValidationSchema = Joi.object({
+  NODE_ENV: Joi.string()
+    .valid('development', 'test', 'production')
+    .default('development'),
+  PORT: Joi.number().port().default(3000),
+  DATABASE_URL: Joi.string()
+    .uri({ scheme: ['postgresql', 'postgres'] })
+    .required(),
+  JWT_SECRET: Joi.string().min(32).required(),
+  JWT_EXPIRATION: Joi.number().integer().positive().default(3600),
+});

--- a/src/modules/config/index.ts
+++ b/src/modules/config/index.ts
@@ -1,0 +1,2 @@
+export * from './configuration';
+export * from './env.validation';

--- a/src/modules/shared/prisma.service.ts
+++ b/src/modules/shared/prisma.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaClient } from '@prisma/client';
 
 function isSafeTestDatabaseUrl(databaseUrl: string) {
@@ -41,11 +42,12 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  constructor() {
+  constructor(private readonly configService: ConfigService) {
     super();
 
-    if (process.env.NODE_ENV === 'test') {
-      assertTestDatabaseUrl(process.env.DATABASE_URL);
+    if (this.configService.get<string>('app.nodeEnv') === 'test') {
+      const databaseUrl = this.configService.get<string>('database.url');
+      assertTestDatabaseUrl(databaseUrl);
     }
   }
 


### PR DESCRIPTION
add Joi-based validation and config namespaces for app, db, jwt update bootstrap, auth, prisma to use ConfigService values safely document .env usage with NODE_ENV/PORT guidance