### PR TITLE
fix: update eslint config and resolve type safety issues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,23 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
       'prettier/prettier': ['error', { endOfLine: 'auto' }],
+    },
+  },
+  // Relaxed rules for test files
+  {
+    files: ['**/*.spec.ts', '**/*.e2e-spec.ts', '**/test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      'no-prototype-builtins': 'off',
     },
   },
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,4 +32,4 @@ async function bootstrap() {
   const port = configService.getOrThrow<number>('app.server.port');
   await app.listen(port);
 }
-bootstrap();
+void bootstrap();

--- a/src/modules/auths/auths.service.ts
+++ b/src/modules/auths/auths.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import * as bcrypt from 'bcryptjs';
 import { RegisterDto } from './dto/register.dto';
@@ -34,9 +35,15 @@ export class AuthsService {
 
       // Generate and return JWT token
       return this.generateToken(user.id, user.email);
-    } catch (error: any) {
+    } catch (error) {
       // Handle Prisma unique constraint violation (P2002)
-      if (error.code === 'P2002') {
+      const isPrismaError =
+        error instanceof Prisma.PrismaClientKnownRequestError ||
+        (typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          typeof (error as { code: unknown }).code === 'string');
+      if (isPrismaError && (error as { code: string }).code === 'P2002') {
         throw new ConflictException('Email already exists');
       }
       throw error;

--- a/src/modules/budgets/budget.service.spec.ts
+++ b/src/modules/budgets/budget.service.spec.ts
@@ -73,7 +73,7 @@ const createPrismaMock = () => {
     budget: {
       findMany: jest.fn(({ where } = {}) => {
         if (!where) {
-          return budgets.map(({ userId, ...rest }) => rest);
+          return budgets.map(({ userId: _userId, ...rest }) => rest);
         }
         return budgets
           .filter((budget) => {
@@ -85,7 +85,7 @@ const createPrismaMock = () => {
             }
             return true;
           })
-          .map(({ userId, ...rest }) => rest);
+          .map(({ userId: _userId, ...rest }) => rest);
       }),
       findUnique: jest.fn(({ where: { id } }) => {
         const budget = budgets.find((budget) => budget.id === id);

--- a/src/modules/budgets/budget.service.ts
+++ b/src/modules/budgets/budget.service.ts
@@ -23,6 +23,45 @@ type BudgetWithSpending = {
   utilizationPercentage: number;
 };
 
+type BudgetBase = {
+  id: string;
+  amount: string;
+  categoryId: string;
+  month: number;
+  year: number;
+  type: BudgetType;
+};
+
+type CategoryInfo = {
+  id: string;
+  name: string;
+  type: string;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+} | null;
+
+type TransactionInfo = {
+  id: string;
+  amount: string;
+  categoryId: string;
+  type: TransactionType;
+  date: string;
+  description: string | null;
+};
+
+type BudgetWithCategory = BudgetBase & {
+  category: CategoryInfo;
+};
+
+type BudgetWithTransactions = BudgetBase & {
+  category: CategoryInfo;
+  transactions: TransactionInfo[];
+  spent: string;
+  remaining: string;
+  utilizationPercentage: number;
+};
+
 @Injectable()
 export class BudgetService {
   constructor(
@@ -65,7 +104,7 @@ export class BudgetService {
 
   private mapBudget(budget: {
     id: string;
-    amount: any;
+    amount: { toString(): string };
     categoryId: string;
     month: number;
     year: number;
@@ -79,7 +118,7 @@ export class BudgetService {
 
   private mapTransaction(transaction: {
     id: string;
-    amount: any;
+    amount: { toString(): string };
     categoryId: string;
     type: TransactionType;
     date: Date;
@@ -141,7 +180,7 @@ export class BudgetService {
       select: this.budgetSelect,
     });
     return budgets.map((budget) => {
-      const { userId: _, ...budgetWithoutUserId } = budget;
+      const { userId: _userId, ...budgetWithoutUserId } = budget;
       return this.mapBudget(budgetWithoutUserId);
     });
   }
@@ -156,7 +195,7 @@ export class BudgetService {
       throw new NotFoundException(`Budget with ID ${id} not found`);
     }
 
-    const { userId: _, ...budgetWithoutUserId } = budget;
+    const { userId: _userId, ...budgetWithoutUserId } = budget;
     return this.mapBudget(budgetWithoutUserId);
   }
 
@@ -193,7 +232,7 @@ export class BudgetService {
         },
         select: this.budgetSelect,
       });
-      const { userId: _, ...budgetWithoutUserId } = newBudget;
+      const { userId: _userId, ...budgetWithoutUserId } = newBudget;
       return this.mapBudget(budgetWithoutUserId);
     } catch (error) {
       if (
@@ -261,7 +300,7 @@ export class BudgetService {
         },
         select: this.budgetSelect,
       });
-      const { userId: _, ...budgetWithoutUserId } = updatedBudget;
+      const { userId: _userId, ...budgetWithoutUserId } = updatedBudget;
       return this.mapBudget(budgetWithoutUserId);
     } catch (error) {
       if (
@@ -297,7 +336,7 @@ export class BudgetService {
       select: this.budgetSelect,
     });
 
-    const { userId: _, ...budgetWithoutUserId } = deletedBudget;
+    const { userId: _userId, ...budgetWithoutUserId } = deletedBudget;
     return this.mapBudget(budgetWithoutUserId);
   }
 
@@ -382,7 +421,10 @@ export class BudgetService {
     return transactions.map((transaction) => this.mapTransaction(transaction));
   }
 
-  async getBudgetWithCategory(budgetId: string, userId: string): Promise<any> {
+  async getBudgetWithCategory(
+    budgetId: string,
+    userId: string,
+  ): Promise<BudgetWithCategory | null> {
     const budget = await this.getBudgetById(budgetId, userId);
     if (!budget) {
       return null;
@@ -410,7 +452,7 @@ export class BudgetService {
   async getBudgetsWithTransactions(
     budgetId: string,
     userId: string,
-  ): Promise<any> {
+  ): Promise<BudgetWithTransactions | null> {
     const budget = await this.getBudgetById(budgetId, userId);
     if (!budget) {
       return null;

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -30,7 +30,7 @@ export class TransactionsService {
 
   private mapTransaction(transaction: {
     id: string;
-    amount: any;
+    amount: { toString(): string };
     type: TransactionType;
     categoryId: string;
     date: Date;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -9,8 +9,8 @@ describe('Personal Finance API E2E', () => {
   let app: INestApplication<App>;
   let user1Token: string;
   let user2Token: string;
-  let user1Id: string;
-  let user2Id: string;
+  let _user1Id: string;
+  let _user2Id: string;
   let categoryId: string;
   let transactionId: string;
   let budgetId: string;
@@ -104,8 +104,8 @@ describe('Personal Finance API E2E', () => {
 
   // ==================== AUTHENTICATION FLOWS ====================
   describe('Authentication Flows', () => {
-    let authUser1Token: string;
-    let authUser2Token: string;
+    let _authUser1Token: string;
+    let _authUser2Token: string;
 
     describe('POST /auths/register', () => {
       it('should register new user and return access token', async () => {
@@ -116,7 +116,7 @@ describe('Personal Finance API E2E', () => {
 
         expect(response.body).toHaveProperty('access_token');
         expect(typeof response.body.access_token).toBe('string');
-        authUser1Token = response.body.access_token;
+        _authUser1Token = response.body.access_token;
       });
 
       it('should register second user with different email', async () => {
@@ -127,7 +127,7 @@ describe('Personal Finance API E2E', () => {
 
         expect(response.body).toHaveProperty('access_token');
         expect(typeof response.body.access_token).toBe('string');
-        authUser2Token = response.body.access_token;
+        _authUser2Token = response.body.access_token;
       });
 
       it('should reject duplicate email registration', async () => {
@@ -400,7 +400,7 @@ describe('Personal Finance API E2E', () => {
           });
 
         // Try to update Category B to Category A name (should fail)
-        const catBId = cat1Response.body.id;
+        const _catBId = cat1Response.body.id;
         const catDiffId = (
           await request(app.getHttpServer())
             .post('/categories')


### PR DESCRIPTION
- Add @typescript-eslint/no-unused-vars rule to ignore _ prefixed variables
- Add relaxed rules for test files (*.spec.ts, *.e2e-spec.ts)
- Fix Prisma error handling type safety in auths.service.ts
- Replace `any` types with proper type definitions in budget and transaction services
- Add explicit return types for getBudgetWithCategory and getBudgetsWithTransactions
- Prefix unused variables with _ in tests and services