### PR TITLE
Docs/update swagger readme documentation

### DIFF
--- a/src/modules/auths/auths.controller.ts
+++ b/src/modules/auths/auths.controller.ts
@@ -1,19 +1,44 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { AuthsService } from './auths.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { AuthResponseDto } from './dto/auth-response.dto';
 
+@ApiTags('auth')
 @Controller('auths')
 export class AuthsController {
   constructor(private readonly authsService: AuthsService) {}
 
   @Post('register')
-  async register(@Body() registerDto: RegisterDto) {
+  @ApiOperation({ summary: 'Register a new user' })
+  @ApiBody({ type: RegisterDto })
+  @ApiResponse({
+    status: 201,
+    description: 'User successfully registered',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - validation error or email already exists',
+  })
+  async register(@Body() registerDto: RegisterDto): Promise<AuthResponseDto> {
     return this.authsService.register(registerDto);
   }
 
   @Post('login')
-  async login(@Body() loginDto: LoginDto) {
+  @ApiOperation({ summary: 'Login with email and password' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully authenticated',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Invalid credentials',
+  })
+  async login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
     return this.authsService.login(loginDto);
   }
 }

--- a/src/modules/auths/dto/auth-response.dto.ts
+++ b/src/modules/auths/dto/auth-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AuthResponseDto {
+  @ApiProperty({
+    description: 'JWT access token for authentication',
+    example:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+  })
+  access_token: string;
+}

--- a/src/modules/auths/dto/login.dto.ts
+++ b/src/modules/auths/dto/login.dto.ts
@@ -1,10 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({
+    description: 'User email address',
+    example: 'user@example.com',
+  })
   @IsEmail()
   @IsNotEmpty()
   email: string;
 
+  @ApiProperty({
+    description: 'User password (minimum 6 characters)',
+    example: 'password123',
+    minLength: 6,
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(6)

--- a/src/modules/auths/dto/register.dto.ts
+++ b/src/modules/auths/dto/register.dto.ts
@@ -1,14 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsEmail, MinLength } from 'class-validator';
 
 export class RegisterDto {
+  @ApiProperty({
+    description: 'User full name',
+    example: 'John Doe',
+  })
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    description: 'User email address',
+    example: 'user@example.com',
+  })
   @IsEmail()
   @IsNotEmpty()
   email: string;
 
+  @ApiProperty({
+    description: 'User password (minimum 6 characters)',
+    example: 'password123',
+    minLength: 6,
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(6)

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -7,7 +7,13 @@ import {
   BadRequestException,
   Req,
 } from '@nestjs/common';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import { DashboardService } from './dashboard.service';
@@ -16,6 +22,7 @@ import { MonthlySummaryDto } from './dto/monthly-summary.dto';
 import { CategoryBreakdownDto } from './dto/category-breakdown.dto';
 import { TopExpenseDto } from './dto/top-expenses.dto';
 
+@ApiTags('dashboard')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('dashboard')
@@ -39,6 +46,21 @@ export class DashboardController {
   }
 
   @Get('monthly-summary')
+  @ApiOperation({ summary: 'Get monthly income, expense and balance summary' })
+  @ApiQuery({
+    name: 'month',
+    type: Number,
+    description: 'Month (1-12)',
+    example: 3,
+  })
+  @ApiQuery({ name: 'year', type: Number, description: 'Year', example: 2026 })
+  @ApiResponse({
+    status: 200,
+    description: 'Monthly summary retrieved successfully',
+    type: MonthlySummaryDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid month parameter' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMonthlySummary(
     @Req() req: AuthenticatedRequest,
     @Query('month', ParseIntPipe) month: number,
@@ -51,6 +73,21 @@ export class DashboardController {
   }
 
   @Get('budget-vs-actual')
+  @ApiOperation({ summary: 'Compare budgets vs actual spending by category' })
+  @ApiQuery({
+    name: 'month',
+    type: Number,
+    description: 'Month (1-12)',
+    example: 3,
+  })
+  @ApiQuery({ name: 'year', type: Number, description: 'Year', example: 2026 })
+  @ApiResponse({
+    status: 200,
+    description: 'Budget vs actual comparison retrieved successfully',
+    type: [BudgetVsActualDto],
+  })
+  @ApiResponse({ status: 400, description: 'Invalid month parameter' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getBudgetVsActual(
     @Req() req: AuthenticatedRequest,
     @Query('month', ParseIntPipe) month: number,
@@ -63,6 +100,21 @@ export class DashboardController {
   }
 
   @Get('category-breakdown')
+  @ApiOperation({ summary: 'Get expense breakdown by category' })
+  @ApiQuery({
+    name: 'month',
+    type: Number,
+    description: 'Month (1-12)',
+    example: 3,
+  })
+  @ApiQuery({ name: 'year', type: Number, description: 'Year', example: 2026 })
+  @ApiResponse({
+    status: 200,
+    description: 'Category breakdown retrieved successfully',
+    type: [CategoryBreakdownDto],
+  })
+  @ApiResponse({ status: 400, description: 'Invalid month parameter' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getCategoryBreakdown(
     @Req() req: AuthenticatedRequest,
     @Query('month', ParseIntPipe) month: number,
@@ -75,6 +127,28 @@ export class DashboardController {
   }
 
   @Get('top-expenses')
+  @ApiOperation({ summary: 'Get top expenses for the month' })
+  @ApiQuery({
+    name: 'month',
+    type: Number,
+    description: 'Month (1-12)',
+    example: 3,
+  })
+  @ApiQuery({ name: 'year', type: Number, description: 'Year', example: 2026 })
+  @ApiQuery({
+    name: 'limit',
+    type: Number,
+    required: false,
+    description: 'Number of top expenses to return (1-100, default: 10)',
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Top expenses retrieved successfully',
+    type: [TopExpenseDto],
+  })
+  @ApiResponse({ status: 400, description: 'Invalid month or limit parameter' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getTopExpenses(
     @Req() req: AuthenticatedRequest,
     @Query('month', ParseIntPipe) month: number,

--- a/src/modules/dashboard/dto/budget-vs-actual.dto.ts
+++ b/src/modules/dashboard/dto/budget-vs-actual.dto.ts
@@ -1,16 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { CategoryType } from '@prisma/client';
 
 export class BudgetVsActualCategoryDto {
+  @ApiProperty({
+    description: 'Category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Food',
+  })
   name: string;
+
+  @ApiProperty({
+    description: 'Category type',
+    enum: ['INCOME', 'EXPENSE'],
+    example: 'EXPENSE',
+  })
   type: CategoryType;
 }
 
 export class BudgetVsActualDto {
+  @ApiProperty({
+    description: 'Category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   categoryId: string;
+
+  @ApiProperty({
+    description: 'Category details',
+    type: BudgetVsActualCategoryDto,
+  })
   category: BudgetVsActualCategoryDto;
+
+  @ApiProperty({
+    description: 'Budgeted amount for the category',
+    example: 500.0,
+  })
   budget: number;
+
+  @ApiProperty({
+    description: 'Actual spent amount',
+    example: 350.0,
+  })
   actual: number;
+
+  @ApiProperty({
+    description:
+      'Difference between budget and actual (positive = under budget)',
+    example: 150.0,
+  })
   difference: number;
+
+  @ApiProperty({
+    description: 'Percentage of budget used',
+    example: 70.0,
+  })
   percentageUsed: number;
 }

--- a/src/modules/dashboard/dto/category-breakdown.dto.ts
+++ b/src/modules/dashboard/dto/category-breakdown.dto.ts
@@ -1,14 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { CategoryType } from '@prisma/client';
 
 export class CategoryBreakdownItemDto {
+  @ApiProperty({
+    description: 'Category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Food',
+  })
   name: string;
+
+  @ApiProperty({
+    description: 'Category type',
+    enum: ['INCOME', 'EXPENSE'],
+    example: 'EXPENSE',
+  })
   type: CategoryType;
 }
 
 export class CategoryBreakdownDto {
+  @ApiProperty({
+    description: 'Category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   categoryId: string;
+
+  @ApiProperty({
+    description: 'Category details',
+    type: CategoryBreakdownItemDto,
+  })
   category: CategoryBreakdownItemDto;
+
+  @ApiProperty({
+    description: 'Total amount spent in this category',
+    example: 350.0,
+  })
   totalAmount: number;
+
+  @ApiProperty({
+    description: 'Percentage of total expenses',
+    example: 25.5,
+  })
   percentage: number;
 }

--- a/src/modules/dashboard/dto/monthly-summary.dto.ts
+++ b/src/modules/dashboard/dto/monthly-summary.dto.ts
@@ -1,5 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class MonthlySummaryDto {
+  @ApiProperty({
+    description: 'Total income for the month',
+    example: 5000.0,
+  })
   totalIncome: number;
+
+  @ApiProperty({
+    description: 'Total expenses for the month',
+    example: 3500.0,
+  })
   totalExpense: number;
+
+  @ApiProperty({
+    description: 'Balance (income - expenses)',
+    example: 1500.0,
+  })
   balance: number;
 }

--- a/src/modules/dashboard/dto/top-expenses.dto.ts
+++ b/src/modules/dashboard/dto/top-expenses.dto.ts
@@ -1,15 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { CategoryType } from '@prisma/client';
 
 export class TopExpenseCategoryDto {
+  @ApiProperty({
+    description: 'Category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Food',
+  })
   name: string;
+
+  @ApiProperty({
+    description: 'Category type',
+    enum: ['INCOME', 'EXPENSE'],
+    example: 'EXPENSE',
+  })
   type: CategoryType;
 }
 
 export class TopExpenseDto {
+  @ApiProperty({
+    description: 'Transaction ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'Transaction description',
+    example: 'Grocery shopping',
+    nullable: true,
+  })
   description: string | null;
+
+  @ApiProperty({
+    description: 'Transaction date',
+    example: '2026-03-01',
+  })
   date: string;
+
+  @ApiProperty({
+    description: 'Transaction amount',
+    example: 150.0,
+  })
   amount: number;
+
+  @ApiProperty({
+    description: 'Category details',
+    type: TopExpenseCategoryDto,
+  })
   category: TopExpenseCategoryDto;
 }

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,9 +1,22 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+class HealthCheckResponseDto {
+  status: string;
+  timestamp: string;
+}
+
+@ApiTags('health')
 @Controller('health')
 export class HealthController {
   @Get()
-  check() {
+  @ApiOperation({ summary: 'Check API health status' })
+  @ApiResponse({
+    status: 200,
+    description: 'API is healthy',
+    type: HealthCheckResponseDto,
+  })
+  check(): HealthCheckResponseDto {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),

--- a/src/modules/shared/utils/format-decimal.ts
+++ b/src/modules/shared/utils/format-decimal.ts
@@ -4,9 +4,11 @@ import { Decimal } from '@prisma/client/runtime/library';
  * Formats a decimal value to a fixed-precision string with 2 decimal places.
  * Used to standardize monetary field serialization across the API.
  *
- * @param value - A Prisma Decimal, number, or string representation of a number
+ * @param value - A Prisma Decimal, number, string, or object with toString() method
  * @returns A string formatted to 2 decimal places (e.g., "500.00")
  */
-export function formatDecimal(value: Decimal | number | string): string {
+export function formatDecimal(
+  value: Decimal | number | string | { toString(): string },
+): string {
   return Number(value).toFixed(2);
 }


### PR DESCRIPTION
- Auth module:
  - Add @apitags, @apioperation, @apiresponse decorators to controller
  - Add @ApiProperty decorators to LoginDto and RegisterDto
  - Create AuthResponseDto for token response documentation

- Dashboard module:
  - Add @apitags, @apioperation, @apiresponse, https://github.com/apiquery decorators to controller
  - Add @ApiProperty decorators to MonthlySummaryDto
  - Add @ApiProperty decorators to BudgetVsActualDto and nested DTOs
  - Add @ApiProperty decorators to CategoryBreakdownDto and nested DTOs
  - Add @ApiProperty decorators to TopExpenseDto and nested DTOs

- Health module:
  - Add @apitags, @apioperation, @apiresponse decorators to controller
  - Add HealthCheckResponseDto for response documentation