### PR TITLE
fix(e2e): resolve .env.test path from monorepo root

### DIFF
--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -2,7 +2,8 @@ import { PrismaClient } from '@prisma/client';
 import fs from 'fs';
 import path from 'path';
 
-const envFilePath = path.resolve(process.cwd(), '.env.test');
+// Resolve .env.test from monorepo root (3 levels up from apps/api/test/)
+const envFilePath = path.resolve(__dirname, '../../..', '.env.test');
 
 function loadEnvFile(filePath: string) {
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
The test setup was looking for .env.test in apps/api/ (process.cwd()) but the file exists at the monorepo root. Changed to use __dirname to correctly resolve the path from apps/api/test/ to the root.