### PR TITLE
feat(budget): use "earned" instead of "spent" for INCOME budgets

### DIFF
--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -788,6 +788,122 @@ describe('BudgetService', () => {
         service.getBudgetWithSpending(missingBudgetId, userId),
       ).rejects.toThrow(NotFoundException);
     });
+
+    describe('INCOME budgets', () => {
+      it('should return earned field instead of spent for INCOME budgets', async () => {
+        const createDto: CreateBudgetDto = {
+          amount: 1000,
+          categoryId,
+          month: 3,
+          year: 2026,
+          type: BudgetType.INCOME,
+        };
+        const budget = await service.createBudget(createDto, userId);
+
+        prismaMock.__setTransactions([
+          {
+            id: 't1',
+            amount: 400,
+            categoryId,
+            type: TransactionType.INCOME,
+            date: new Date('2026-03-15T00:00:00.000Z'),
+            description: 'Income 1',
+            userId,
+          },
+        ]);
+
+        const result = await service.getBudgetWithSpending(budget.id, userId);
+
+        if (!result) {
+          throw new Error('Expected budget with spending to be defined');
+        }
+
+        expect(result.type).toBe(BudgetType.INCOME);
+        expect('earned' in result && result.earned).toBe('400.00');
+        expect('spent' in result).toBe(false);
+        expect(result.remaining).toBe('600.00');
+        expect(result.utilizationPercentage).toBe(40);
+      });
+
+      it('should calculate INCOME utilization correctly with multiple transactions', async () => {
+        const createDto: CreateBudgetDto = {
+          amount: 2000,
+          categoryId,
+          month: 4,
+          year: 2026,
+          type: BudgetType.INCOME,
+        };
+        const budget = await service.createBudget(createDto, userId);
+
+        prismaMock.__setTransactions([
+          {
+            id: 't1',
+            amount: 800,
+            categoryId,
+            type: TransactionType.INCOME,
+            date: new Date('2026-04-10T00:00:00.000Z'),
+            description: 'Salary',
+            userId,
+          },
+          {
+            id: 't2',
+            amount: 400,
+            categoryId,
+            type: TransactionType.INCOME,
+            date: new Date('2026-04-20T00:00:00.000Z'),
+            description: 'Bonus',
+            userId,
+          },
+        ]);
+
+        const result = await service.getBudgetWithSpending(budget.id, userId);
+
+        if (!result) {
+          throw new Error('Expected budget with spending to be defined');
+        }
+
+        expect(result.type).toBe(BudgetType.INCOME);
+        expect('earned' in result && result.earned).toBe('1200.00');
+        expect(result.remaining).toBe('800.00');
+        expect(result.utilizationPercentage).toBe(60);
+      });
+    });
+
+    describe('EXPENSE budgets (regression)', () => {
+      it('should return spent field for EXPENSE budgets', async () => {
+        const createDto: CreateBudgetDto = {
+          amount: 500,
+          categoryId,
+          month: 5,
+          year: 2026,
+          type: BudgetType.EXPENSE,
+        };
+        const budget = await service.createBudget(createDto, userId);
+
+        prismaMock.__setTransactions([
+          {
+            id: 't1',
+            amount: 200,
+            categoryId,
+            type: TransactionType.EXPENSE,
+            date: new Date('2026-05-15T00:00:00.000Z'),
+            description: 'Expense 1',
+            userId,
+          },
+        ]);
+
+        const result = await service.getBudgetWithSpending(budget.id, userId);
+
+        if (!result) {
+          throw new Error('Expected budget with spending to be defined');
+        }
+
+        expect(result.type).toBe(BudgetType.EXPENSE);
+        expect('spent' in result && result.spent).toBe('200.00');
+        expect('earned' in result).toBe(false);
+        expect(result.remaining).toBe('300.00');
+      });
+    });
   });
 
   describe('getBudgetWithCategory', () => {
@@ -952,6 +1068,95 @@ describe('BudgetService', () => {
       expect(result?.transactions).toEqual([]);
       expect(result?.spent).toBe('0.00');
       expect(result?.utilizationPercentage).toBe(0);
+    });
+
+    describe('INCOME budgets', () => {
+      it('should return earned field instead of spent for INCOME budget with transactions', async () => {
+        const createDto: CreateBudgetDto = {
+          amount: 3000,
+          categoryId,
+          month: 6,
+          year: 2026,
+          type: BudgetType.INCOME,
+        };
+        const budget = await service.createBudget(createDto, userId);
+
+        prismaMock.__setTransactions([
+          {
+            id: 't1',
+            amount: 1500,
+            categoryId,
+            type: TransactionType.INCOME,
+            date: new Date('2026-06-10T00:00:00.000Z'),
+            description: 'Salary',
+            userId,
+          },
+          {
+            id: 't2',
+            amount: 500,
+            categoryId,
+            type: TransactionType.INCOME,
+            date: new Date('2026-06-25T00:00:00.000Z'),
+            description: 'Freelance',
+            userId,
+          },
+        ]);
+
+        const result = await service.getBudgetsWithTransactions(
+          budget.id,
+          userId,
+        );
+
+        if (!result) {
+          throw new Error('Expected budget with transactions to be defined');
+        }
+
+        expect(result.type).toBe(BudgetType.INCOME);
+        expect('earned' in result && result.earned).toBe('2000.00');
+        expect('spent' in result).toBe(false);
+        expect(result.remaining).toBe('1000.00');
+        expect(result.utilizationPercentage).toBeCloseTo(66.67, 1);
+        expect(result.transactions).toHaveLength(2);
+      });
+    });
+
+    describe('EXPENSE budgets (regression)', () => {
+      it('should return spent field for EXPENSE budget with transactions', async () => {
+        const createDto: CreateBudgetDto = {
+          amount: 800,
+          categoryId,
+          month: 7,
+          year: 2026,
+          type: BudgetType.EXPENSE,
+        };
+        const budget = await service.createBudget(createDto, userId);
+
+        prismaMock.__setTransactions([
+          {
+            id: 't1',
+            amount: 300,
+            categoryId,
+            type: TransactionType.EXPENSE,
+            date: new Date('2026-07-15T00:00:00.000Z'),
+            description: 'Groceries',
+            userId,
+          },
+        ]);
+
+        const result = await service.getBudgetsWithTransactions(
+          budget.id,
+          userId,
+        );
+
+        if (!result) {
+          throw new Error('Expected budget with transactions to be defined');
+        }
+
+        expect(result.type).toBe(BudgetType.EXPENSE);
+        expect('spent' in result && result.spent).toBe('300.00');
+        expect('earned' in result).toBe(false);
+        expect(result.remaining).toBe('500.00');
+      });
     });
   });
 
@@ -1210,7 +1415,7 @@ describe('BudgetService', () => {
       expect(budget.amount).toMatch(/^\d+\.\d{2}$/);
     });
 
-    it('should serialize spending fields as fixed-precision strings', async () => {
+    it('should serialize spending fields as fixed-precision strings for EXPENSE budgets', async () => {
       const createDto: CreateBudgetDto = {
         amount: 500,
         categoryId,
@@ -1227,11 +1432,52 @@ describe('BudgetService', () => {
 
       // Monetary fields should be strings with 2 decimal places
       expect(typeof result.amount).toBe('string');
-      expect(typeof result.spent).toBe('string');
       expect(typeof result.remaining).toBe('string');
       expect(result.amount).toMatch(/^-?\d+\.\d{2}$/);
-      expect(result.spent).toMatch(/^-?\d+\.\d{2}$/);
       expect(result.remaining).toMatch(/^-?\d+\.\d{2}$/);
+
+      // EXPENSE budget should have spent field
+      expect(result.type).toBe(BudgetType.EXPENSE);
+      if ('spent' in result) {
+        expect(typeof result.spent).toBe('string');
+        expect(result.spent).toMatch(/^-?\d+\.\d{2}$/);
+      } else {
+        throw new Error('Expected spent field for EXPENSE budget');
+      }
+
+      // utilizationPercentage should remain a number
+      expect(typeof result.utilizationPercentage).toBe('number');
+    });
+
+    it('should serialize earned field as fixed-precision string for INCOME budgets', async () => {
+      const createDto: CreateBudgetDto = {
+        amount: 1000,
+        categoryId,
+        month: 2,
+        year: 2026,
+        type: BudgetType.INCOME,
+      };
+      const budget = await service.createBudget(createDto, userId);
+      const result = await service.getBudgetWithSpending(budget.id, userId);
+
+      if (!result) {
+        throw new Error('Expected budget with spending to be defined');
+      }
+
+      // Monetary fields should be strings with 2 decimal places
+      expect(typeof result.amount).toBe('string');
+      expect(typeof result.remaining).toBe('string');
+      expect(result.amount).toMatch(/^-?\d+\.\d{2}$/);
+      expect(result.remaining).toMatch(/^-?\d+\.\d{2}$/);
+
+      // INCOME budget should have earned field
+      expect(result.type).toBe(BudgetType.INCOME);
+      if ('earned' in result) {
+        expect(typeof result.earned).toBe('string');
+        expect(result.earned).toMatch(/^-?\d+\.\d{2}$/);
+      } else {
+        throw new Error('Expected earned field for INCOME budget');
+      }
 
       // utilizationPercentage should remain a number
       expect(typeof result.utilizationPercentage).toBe('number');

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -11,17 +11,31 @@ import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
 import { formatDecimal } from '../shared';
 
-type BudgetWithSpending = {
+type BudgetWithSpendingExpense = {
   id: string;
   amount: string;
   categoryId: string;
   month: number;
   year: number;
-  type: BudgetType;
+  type: typeof BudgetType.EXPENSE;
   spent: string;
   remaining: string;
   utilizationPercentage: number;
 };
+
+type BudgetWithSpendingIncome = {
+  id: string;
+  amount: string;
+  categoryId: string;
+  month: number;
+  year: number;
+  type: typeof BudgetType.INCOME;
+  earned: string;
+  remaining: string;
+  utilizationPercentage: number;
+};
+
+type BudgetWithSpending = BudgetWithSpendingExpense | BudgetWithSpendingIncome;
 
 type BudgetBase = {
   id: string;
@@ -54,13 +68,27 @@ type BudgetWithCategory = BudgetBase & {
   category: CategoryInfo;
 };
 
-type BudgetWithTransactions = BudgetBase & {
+type BudgetWithTransactionsExpense = BudgetBase & {
+  type: typeof BudgetType.EXPENSE;
   category: CategoryInfo;
   transactions: TransactionInfo[];
   spent: string;
   remaining: string;
   utilizationPercentage: number;
 };
+
+type BudgetWithTransactionsIncome = BudgetBase & {
+  type: typeof BudgetType.INCOME;
+  category: CategoryInfo;
+  transactions: TransactionInfo[];
+  earned: string;
+  remaining: string;
+  utilizationPercentage: number;
+};
+
+type BudgetWithTransactions =
+  | BudgetWithTransactionsExpense
+  | BudgetWithTransactionsIncome;
 
 @Injectable()
 export class BudgetService {
@@ -383,15 +411,26 @@ export class BudgetService {
       return null;
     }
 
-    const spent = await this.calculateSpentAmount(budget, userId);
+    const progressAmount = await this.calculateSpentAmount(budget, userId);
     const numericAmount = Number(budget.amount);
-    const remaining = numericAmount - spent;
+    const remaining = numericAmount - progressAmount;
     const utilizationPercentage =
-      numericAmount > 0 ? (spent / numericAmount) * 100 : 0;
+      numericAmount > 0 ? (progressAmount / numericAmount) * 100 : 0;
+
+    if (budget.type === BudgetType.INCOME) {
+      return {
+        ...budget,
+        type: BudgetType.INCOME,
+        earned: formatDecimal(progressAmount),
+        remaining: formatDecimal(remaining),
+        utilizationPercentage,
+      };
+    }
 
     return {
       ...budget,
-      spent: formatDecimal(spent),
+      type: BudgetType.EXPENSE,
+      spent: formatDecimal(progressAmount),
       remaining: formatDecimal(remaining),
       utilizationPercentage,
     };
@@ -471,20 +510,33 @@ export class BudgetService {
       }
     }
 
-    const [transactions, spent] = await Promise.all([
+    const [transactions, progressAmount] = await Promise.all([
       this.getTransactionsForBudget(budgetId, userId),
       this.calculateSpentAmount(budget, userId),
     ]);
     const numericAmount = Number(budget.amount);
-    const remaining = numericAmount - spent;
+    const remaining = numericAmount - progressAmount;
     const utilizationPercentage =
-      numericAmount > 0 ? (spent / numericAmount) * 100 : 0;
+      numericAmount > 0 ? (progressAmount / numericAmount) * 100 : 0;
+
+    if (budget.type === BudgetType.INCOME) {
+      return {
+        ...budget,
+        type: BudgetType.INCOME,
+        category: category || null,
+        transactions,
+        earned: formatDecimal(progressAmount),
+        remaining: formatDecimal(remaining),
+        utilizationPercentage,
+      };
+    }
 
     return {
       ...budget,
+      type: BudgetType.EXPENSE,
       category: category || null,
       transactions,
-      spent: formatDecimal(spent),
+      spent: formatDecimal(progressAmount),
       remaining: formatDecimal(remaining),
       utilizationPercentage,
     };
@@ -502,15 +554,26 @@ export class BudgetService {
     const results = await Promise.all(
       budgets.map(async (budget) => {
         const mapped = this.mapBudget(budget);
-        const spent = await this.calculateSpentAmount(mapped, userId);
+        const progressAmount = await this.calculateSpentAmount(mapped, userId);
         const numericAmount = Number(mapped.amount);
-        const remaining = numericAmount - spent;
+        const remaining = numericAmount - progressAmount;
         const utilizationPercentage =
-          numericAmount > 0 ? (spent / numericAmount) * 100 : 0;
+          numericAmount > 0 ? (progressAmount / numericAmount) * 100 : 0;
+
+        if (budget.type === BudgetType.INCOME) {
+          return {
+            ...mapped,
+            type: BudgetType.INCOME,
+            earned: formatDecimal(progressAmount),
+            remaining: formatDecimal(remaining),
+            utilizationPercentage,
+          };
+        }
 
         return {
           ...mapped,
-          spent: formatDecimal(spent),
+          type: BudgetType.EXPENSE,
+          spent: formatDecimal(progressAmount),
           remaining: formatDecimal(remaining),
           utilizationPercentage,
         };

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -43,9 +43,25 @@ type FilterCategory = 'ALL' | string;
 
 // Combined type for budgets with optional spending info
 type BudgetDisplay = Budget &
-  Partial<
-    Pick<BudgetWithSpending, 'spent' | 'remaining' | 'utilizationPercentage'>
-  >;
+  Partial<{
+    spent?: string;
+    earned?: string;
+    remaining: string;
+    utilizationPercentage: number;
+  }>;
+
+// Get the progress value (spent for EXPENSE, earned for INCOME)
+function getProgressValue(budget: BudgetDisplay): string | undefined {
+  if (budget.type === BudgetType.INCOME) {
+    return budget.earned;
+  }
+  return budget.spent;
+}
+
+// Get the progress label based on budget type
+function getProgressLabel(budgetType: BudgetType): string {
+  return budgetType === BudgetType.INCOME ? 'Earned' : 'Spent';
+}
 
 const MONTHS = [
   { value: 1, label: 'January' },
@@ -81,8 +97,18 @@ function getUniqueYears(budgets: BudgetDisplay[]): number[] {
   return years.sort((a, b) => b - a); // Sort descending
 }
 
-function getUtilizationColor(percentage: number | undefined): string {
+function getUtilizationColor(
+  percentage: number | undefined,
+  budgetType?: BudgetType,
+): string {
   if (percentage === undefined) return '';
+  if (budgetType === BudgetType.INCOME) {
+    // For INCOME: higher percentage is better (more earned toward goal)
+    if (percentage >= 75) return 'text-green-600';
+    if (percentage >= 50) return 'text-yellow-600';
+    return 'text-red-600';
+  }
+  // For EXPENSE: lower percentage is better (less spent)
   if (percentage >= 100) return 'text-red-600';
   if (percentage >= 75) return 'text-yellow-600';
   return 'text-green-600';
@@ -326,7 +352,7 @@ export default function BudgetsPage() {
                 <TableHead>Amount</TableHead>
                 {hasSpendingInfo && (
                   <>
-                    <TableHead>Spent</TableHead>
+                    <TableHead>Spent/Earned</TableHead>
                     <TableHead>Remaining</TableHead>
                     <TableHead>Usage</TableHead>
                   </>
@@ -337,71 +363,74 @@ export default function BudgetsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredBudgets.map((budget) => (
-                <TableRow
-                  key={budget.id}
-                  className="cursor-pointer hover:bg-muted/50"
-                  onClick={() => router.push(`/budgets/${budget.id}`)}
-                >
-                  <TableCell className="font-medium">
-                    {categoryMap[budget.categoryId] || 'Unknown'}
-                  </TableCell>
-                  <TableCell>{formatAmount(budget.amount)}</TableCell>
-                  {hasSpendingInfo && budget.spent !== undefined && (
-                    <>
-                      <TableCell>{formatAmount(budget.spent)}</TableCell>
-                      <TableCell
-                        className={
-                          parseFloat(budget.remaining || '0') < 0
-                            ? 'text-red-600'
-                            : ''
-                        }
+              {filteredBudgets.map((budget) => {
+                const progressValue = getProgressValue(budget);
+                return (
+                  <TableRow
+                    key={budget.id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => router.push(`/budgets/${budget.id}`)}
+                  >
+                    <TableCell className="font-medium">
+                      {categoryMap[budget.categoryId] || 'Unknown'}
+                    </TableCell>
+                    <TableCell>{formatAmount(budget.amount)}</TableCell>
+                    {hasSpendingInfo && progressValue !== undefined && (
+                      <>
+                        <TableCell>{formatAmount(progressValue)}</TableCell>
+                        <TableCell
+                          className={
+                            parseFloat(budget.remaining || '0') < 0
+                              ? 'text-red-600'
+                              : ''
+                          }
+                        >
+                          {formatAmount(budget.remaining || '0')}
+                        </TableCell>
+                        <TableCell
+                          className={`font-medium ${getUtilizationColor(budget.utilizationPercentage, budget.type)}`}
+                        >
+                          {budget.utilizationPercentage?.toFixed(1)}%
+                        </TableCell>
+                      </>
+                    )}
+                    <TableCell className="text-gray-500">
+                      {formatPeriod(budget.month, budget.year)}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          budget.type === 'INCOME'
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-red-100 text-red-800'
+                        }`}
                       >
-                        {formatAmount(budget.remaining || '0')}
-                      </TableCell>
-                      <TableCell
-                        className={`font-medium ${getUtilizationColor(budget.utilizationPercentage)}`}
+                        {budget.type}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Link
+                        href={`/budgets/${budget.id}/edit`}
+                        onClick={(e) => e.stopPropagation()}
                       >
-                        {budget.utilizationPercentage?.toFixed(1)}%
-                      </TableCell>
-                    </>
-                  )}
-                  <TableCell className="text-gray-500">
-                    {formatPeriod(budget.month, budget.year)}
-                  </TableCell>
-                  <TableCell>
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        budget.type === 'INCOME'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-red-100 text-red-800'
-                      }`}
-                    >
-                      {budget.type}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-right space-x-2">
-                    <Link
-                      href={`/budgets/${budget.id}/edit`}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Button variant="outline" size="sm">
-                        Edit
+                        <Button variant="outline" size="sm">
+                          Edit
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDeleteBudget(budget);
+                        }}
+                      >
+                        Delete
                       </Button>
-                    </Link>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setDeleteBudget(budget);
-                      }}
-                    >
-                      Delete
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/apps/web/src/components/BudgetDetails.test.tsx
+++ b/apps/web/src/components/BudgetDetails.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BudgetDetails } from './BudgetDetails';
-import { BudgetType, BudgetWithDetails, CategoryType } from '@/types';
+import {
+  BudgetType,
+  BudgetWithDetailsExpense,
+  BudgetWithDetailsIncome,
+  CategoryType,
+  TransactionType,
+} from '@/types';
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
@@ -12,7 +18,7 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-const mockBudgetBase: BudgetWithDetails = {
+const mockExpenseBudget: BudgetWithDetailsExpense = {
   id: 'budget-1',
   amount: '500.00',
   categoryId: 'cat-1',
@@ -32,16 +38,36 @@ const mockBudgetBase: BudgetWithDetails = {
   utilizationPercentage: 30,
 };
 
+const mockIncomeBudget: BudgetWithDetailsIncome = {
+  id: 'budget-2',
+  amount: '2000.00',
+  categoryId: 'cat-2',
+  month: 3,
+  year: 2026,
+  type: BudgetType.INCOME,
+  category: {
+    id: 'cat-2',
+    name: 'Salary',
+    type: CategoryType.INCOME,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  },
+  transactions: [],
+  earned: '1500.00',
+  remaining: '500.00',
+  utilizationPercentage: 75,
+};
+
 describe('BudgetDetails', () => {
   it('should render budget title and category', () => {
-    render(<BudgetDetails budget={mockBudgetBase} />);
+    render(<BudgetDetails budget={mockExpenseBudget} />);
 
     expect(screen.getByTestId('budget-title')).toHaveTextContent('Groceries');
     expect(screen.getByText('March 2026')).toBeInTheDocument();
   });
 
   it('should render budget type badge', () => {
-    render(<BudgetDetails budget={mockBudgetBase} />);
+    render(<BudgetDetails budget={mockExpenseBudget} />);
 
     const badge = screen.getByTestId('budget-type-badge');
     expect(badge).toHaveTextContent('EXPENSE');
@@ -49,12 +75,7 @@ describe('BudgetDetails', () => {
   });
 
   it('should render income type badge with correct styling', () => {
-    const incomeBudget: BudgetWithDetails = {
-      ...mockBudgetBase,
-      type: BudgetType.INCOME,
-    };
-
-    render(<BudgetDetails budget={incomeBudget} />);
+    render(<BudgetDetails budget={mockIncomeBudget} />);
 
     const badge = screen.getByTestId('budget-type-badge');
     expect(badge).toHaveTextContent('INCOME');
@@ -62,30 +83,43 @@ describe('BudgetDetails', () => {
   });
 
   it('should render budget amount formatted as currency', () => {
-    render(<BudgetDetails budget={mockBudgetBase} />);
+    render(<BudgetDetails budget={mockExpenseBudget} />);
 
     expect(screen.getByTestId('budget-amount')).toHaveTextContent('$500.00');
   });
 
-  it('should render spent and remaining amounts', () => {
-    render(<BudgetDetails budget={mockBudgetBase} />);
+  it('should render spent label and amount for EXPENSE budgets', () => {
+    render(<BudgetDetails budget={mockExpenseBudget} />);
 
-    expect(screen.getByTestId('budget-spent')).toHaveTextContent('$150.00');
+    expect(screen.getByText('Spent')).toBeInTheDocument();
+    expect(screen.getByTestId('budget-progress-value')).toHaveTextContent(
+      '$150.00',
+    );
     expect(screen.getByTestId('budget-remaining')).toHaveTextContent('$350.00');
   });
 
+  it('should render earned label and amount for INCOME budgets', () => {
+    render(<BudgetDetails budget={mockIncomeBudget} />);
+
+    expect(screen.getByText('Earned')).toBeInTheDocument();
+    expect(screen.getByTestId('budget-progress-value')).toHaveTextContent(
+      '$1,500.00',
+    );
+    expect(screen.getByTestId('budget-remaining')).toHaveTextContent('$500.00');
+  });
+
   it('should render utilization percentage', () => {
-    render(<BudgetDetails budget={mockBudgetBase} />);
+    render(<BudgetDetails budget={mockExpenseBudget} />);
 
     expect(screen.getByTestId('utilization-percentage')).toHaveTextContent(
       '30.0%',
     );
   });
 
-  describe('progress bar colors', () => {
+  describe('progress bar colors for EXPENSE budgets', () => {
     it('should render green progress bar for low utilization (<75%)', () => {
-      const lowUsageBudget: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const lowUsageBudget: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         spent: '150.00',
         remaining: '350.00',
         utilizationPercentage: 30,
@@ -98,8 +132,8 @@ describe('BudgetDetails', () => {
     });
 
     it('should render yellow progress bar for medium utilization (>=75%, <100%)', () => {
-      const mediumUsageBudget: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const mediumUsageBudget: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         spent: '400.00',
         remaining: '100.00',
         utilizationPercentage: 80,
@@ -112,8 +146,8 @@ describe('BudgetDetails', () => {
     });
 
     it('should render red progress bar for high utilization (>=100%)', () => {
-      const highUsageBudget: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const highUsageBudget: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         spent: '550.00',
         remaining: '-50.00',
         utilizationPercentage: 110,
@@ -126,8 +160,8 @@ describe('BudgetDetails', () => {
     });
 
     it('should cap progress bar width at 100%', () => {
-      const overBudget: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const overBudget: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         spent: '750.00',
         remaining: '-250.00',
         utilizationPercentage: 150,
@@ -140,10 +174,54 @@ describe('BudgetDetails', () => {
     });
   });
 
+  describe('progress bar colors for INCOME budgets (inverted)', () => {
+    it('should render red progress bar for low utilization (<50%)', () => {
+      const lowEarnedBudget: BudgetWithDetailsIncome = {
+        ...mockIncomeBudget,
+        earned: '400.00',
+        remaining: '1600.00',
+        utilizationPercentage: 20,
+      };
+
+      render(<BudgetDetails budget={lowEarnedBudget} />);
+
+      const progressBar = screen.getByTestId('progress-bar');
+      expect(progressBar).toHaveClass('bg-red-500');
+    });
+
+    it('should render yellow progress bar for medium utilization (>=50%, <75%)', () => {
+      const mediumEarnedBudget: BudgetWithDetailsIncome = {
+        ...mockIncomeBudget,
+        earned: '1200.00',
+        remaining: '800.00',
+        utilizationPercentage: 60,
+      };
+
+      render(<BudgetDetails budget={mediumEarnedBudget} />);
+
+      const progressBar = screen.getByTestId('progress-bar');
+      expect(progressBar).toHaveClass('bg-yellow-500');
+    });
+
+    it('should render green progress bar for high utilization (>=75%)', () => {
+      const highEarnedBudget: BudgetWithDetailsIncome = {
+        ...mockIncomeBudget,
+        earned: '1800.00',
+        remaining: '200.00',
+        utilizationPercentage: 90,
+      };
+
+      render(<BudgetDetails budget={highEarnedBudget} />);
+
+      const progressBar = screen.getByTestId('progress-bar');
+      expect(progressBar).toHaveClass('bg-green-500');
+    });
+  });
+
   describe('negative remaining', () => {
     it('should show remaining in red when negative', () => {
-      const overBudget: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const overBudget: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         spent: '600.00',
         remaining: '-100.00',
         utilizationPercentage: 120,
@@ -159,7 +237,7 @@ describe('BudgetDetails', () => {
 
   describe('transactions', () => {
     it('should show no transactions message when empty', () => {
-      render(<BudgetDetails budget={mockBudgetBase} />);
+      render(<BudgetDetails budget={mockExpenseBudget} />);
 
       expect(screen.getByTestId('no-transactions')).toHaveTextContent(
         'No transactions found for this budget period.',
@@ -167,13 +245,13 @@ describe('BudgetDetails', () => {
     });
 
     it('should render transactions table when transactions exist', () => {
-      const budgetWithTransactions: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const budgetWithTransactions: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         transactions: [
           {
             id: 'tx-1',
             amount: '75.00',
-            type: 'EXPENSE' as const,
+            type: TransactionType.EXPENSE,
             categoryId: 'cat-1',
             date: '2026-03-15T10:00:00.000Z',
             description: 'Weekly groceries',
@@ -184,10 +262,10 @@ describe('BudgetDetails', () => {
           {
             id: 'tx-2',
             amount: '75.00',
-            type: 'EXPENSE' as const,
+            type: TransactionType.EXPENSE,
             categoryId: 'cat-1',
             date: '2026-03-08T10:00:00.000Z',
-            description: null,
+            description: undefined,
             userId: 'user-1',
             createdAt: '2026-03-08T10:00:00.000Z',
             updatedAt: '2026-03-08T10:00:00.000Z',
@@ -213,8 +291,8 @@ describe('BudgetDetails', () => {
 
   describe('null category', () => {
     it('should show Unknown Category when category is null', () => {
-      const budgetWithNullCategory: BudgetWithDetails = {
-        ...mockBudgetBase,
+      const budgetWithNullCategory: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
         category: null,
       };
 
@@ -228,14 +306,14 @@ describe('BudgetDetails', () => {
 
   describe('navigation links', () => {
     it('should render Edit Budget link', () => {
-      render(<BudgetDetails budget={mockBudgetBase} />);
+      render(<BudgetDetails budget={mockExpenseBudget} />);
 
       const editLink = screen.getByRole('link', { name: 'Edit Budget' });
       expect(editLink).toHaveAttribute('href', '/budgets/budget-1/edit');
     });
 
     it('should render Back to Budgets link', () => {
-      render(<BudgetDetails budget={mockBudgetBase} />);
+      render(<BudgetDetails budget={mockExpenseBudget} />);
 
       const backLink = screen.getByRole('link', { name: 'Back to Budgets' });
       expect(backLink).toHaveAttribute('href', '/budgets');

--- a/apps/web/src/components/BudgetDetails.tsx
+++ b/apps/web/src/components/BudgetDetails.tsx
@@ -59,24 +59,59 @@ function formatDate(dateString: string): string {
   });
 }
 
-function getUtilizationColor(percentage: number): string {
+function getUtilizationColor(
+  percentage: number,
+  budgetType: BudgetType,
+): string {
+  if (budgetType === BudgetType.INCOME) {
+    // For INCOME: higher percentage is better (more earned toward goal)
+    if (percentage >= 100) return 'bg-green-500';
+    if (percentage >= 75) return 'bg-green-500';
+    if (percentage >= 50) return 'bg-yellow-500';
+    return 'bg-red-500';
+  }
+  // For EXPENSE: lower percentage is better (less spent)
   if (percentage >= 100) return 'bg-red-500';
   if (percentage >= 75) return 'bg-yellow-500';
   return 'bg-green-500';
 }
 
-function getUtilizationTextColor(percentage: number): string {
+function getUtilizationTextColor(
+  percentage: number,
+  budgetType: BudgetType,
+): string {
+  if (budgetType === BudgetType.INCOME) {
+    // For INCOME: higher percentage is better
+    if (percentage >= 75) return 'text-green-600';
+    if (percentage >= 50) return 'text-yellow-600';
+    return 'text-red-600';
+  }
+  // For EXPENSE: lower percentage is better
   if (percentage >= 100) return 'text-red-600';
   if (percentage >= 75) return 'text-yellow-600';
   return 'text-green-600';
 }
 
+function getProgressValue(budget: BudgetWithDetails): string {
+  return budget.type === BudgetType.INCOME ? budget.earned : budget.spent;
+}
+
+function getProgressLabel(budgetType: BudgetType): string {
+  return budgetType === BudgetType.INCOME ? 'Earned' : 'Spent';
+}
+
 export function BudgetDetails({ budget }: BudgetDetailsProps) {
-  const utilizationColor = getUtilizationColor(budget.utilizationPercentage);
+  const utilizationColor = getUtilizationColor(
+    budget.utilizationPercentage,
+    budget.type,
+  );
   const utilizationTextColor = getUtilizationTextColor(
     budget.utilizationPercentage,
+    budget.type,
   );
   const progressWidth = Math.min(budget.utilizationPercentage, 100);
+  const progressLabel = getProgressLabel(budget.type);
+  const progressValue = getProgressValue(budget);
 
   return (
     <div className="space-y-6">
@@ -136,15 +171,15 @@ export function BudgetDetails({ budget }: BudgetDetailsProps) {
             </div>
           </div>
 
-          {/* Spent and Remaining */}
+          {/* Spent/Earned and Remaining */}
           <div className="grid grid-cols-2 gap-4">
             <div className="p-4 rounded-lg bg-gray-50">
-              <p className="text-sm text-muted-foreground">Spent</p>
+              <p className="text-sm text-muted-foreground">{progressLabel}</p>
               <p
                 className="text-lg font-semibold text-gray-900"
-                data-testid="budget-spent"
+                data-testid="budget-progress-value"
               >
-                {formatAmount(budget.spent)}
+                {formatAmount(progressValue)}
               </p>
             </div>
             <div className="p-4 rounded-lg bg-gray-50">

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -106,7 +106,7 @@ export const mockBudgetsWithSpending = [
     month: 3,
     year: 2026,
     type: 'INCOME',
-    spent: '3000.00',
+    earned: '3000.00',
     remaining: '0.00',
     utilizationPercentage: 100,
   },

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -76,22 +76,43 @@ export interface UpdateBudgetDto {
   type?: BudgetType;
 }
 
-export interface BudgetWithSpending {
+interface BudgetWithSpendingBase {
   id: string;
   amount: string;
   categoryId: string;
   month: number;
   year: number;
-  type: BudgetType;
-  spent: string;
   remaining: string;
   utilizationPercentage: number;
 }
 
-export interface BudgetWithDetails extends BudgetWithSpending {
+export interface BudgetWithSpendingExpense extends BudgetWithSpendingBase {
+  type: BudgetType.EXPENSE;
+  spent: string;
+}
+
+export interface BudgetWithSpendingIncome extends BudgetWithSpendingBase {
+  type: BudgetType.INCOME;
+  earned: string;
+}
+
+export type BudgetWithSpending =
+  | BudgetWithSpendingExpense
+  | BudgetWithSpendingIncome;
+
+export interface BudgetWithDetailsExpense extends BudgetWithSpendingExpense {
   category: Category | null;
   transactions: Transaction[];
 }
+
+export interface BudgetWithDetailsIncome extends BudgetWithSpendingIncome {
+  category: Category | null;
+  transactions: Transaction[];
+}
+
+export type BudgetWithDetails =
+  | BudgetWithDetailsExpense
+  | BudgetWithDetailsIncome;
 
 // Transaction types
 export enum TransactionType {


### PR DESCRIPTION
- Update backend types to use discriminated unions for BudgetWithSpending and BudgetWithTransactions (EXPENSE has 'spent', INCOME has 'earned')
- Update getBudgetWithSpending, getBudgetsWithTransactions, and getBudgetsByCategory methods to return appropriate field per type
- Add backend tests for INCOME budgets and regression tests for EXPENSE
- Update frontend types with discriminated union pattern
- Update BudgetDetails component: show "Earned" label for INCOME, invert progress bar colors (green=high, red=low for INCOME)
- Update budgets table page with "Spent/Earned" column
- Update frontend tests for new INCOME budget behavior
- Update mock data handlers