### PR TITLE
feat(dashboard): implement dashboard UI as post-login landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+```bash
+npm install                  # Install all workspace dependencies
+npm run dev                  # Start all apps (API on :3001, web on :3000)
+npm run dev:api              # Backend only
+npm run dev:web              # Frontend only
+npm run lint                 # Lint all apps
+npm run format               # Prettier format
+```
+
+### Testing
+```bash
+npm run test                          # Run all tests via Turborepo
+npm run test:cov                      # With coverage
+
+# API unit tests (Jest, NODE_ENV=test)
+cd apps/api && npm run test           # All unit tests
+cd apps/api && npm run test:watch     # Watch mode
+cd apps/api && npm test -- --testPathPattern=auths  # Single module
+
+# API e2e tests
+cd apps/api && npm run test:e2e       # Requires test DB running on port 5433
+
+# Web tests (Vitest + Testing Library + MSW)
+cd apps/web && npm run test           # Watch mode
+cd apps/web && npm run test:run       # Single run
+cd apps/web && npm run test:coverage  # With coverage
+```
+
+### Database
+```bash
+npm run db:generate          # Regenerate Prisma client after schema changes
+npm run db:migrate:dev       # Run migrations (dev DB)
+npm run db:migrate:test      # Run migrations against test DB (port 5433)
+npm run db:studio            # Open Prisma Studio
+npm run db:seed              # Seed database
+```
+
+### Docker
+```bash
+npm run docker:dev           # Start all services with hot-reload
+npm run docker:dev:build     # Rebuild and start
+npm run docker:dev:down      # Stop
+```
+
+## Architecture
+
+### Monorepo Structure
+This is a **Turborepo + npm workspaces** monorepo:
+- `apps/api` — NestJS backend (`@my-pocket/api`)
+- `apps/web` — Next.js 15 frontend (`@my-pocket/web`)
+- `packages/shared` — shared TypeScript types/interfaces (`@my-pocket/shared`)
+- `prisma/` — single Prisma schema at root, shared by all apps
+
+### Backend (`apps/api`)
+
+**NestJS modular architecture** under `src/modules/`:
+- `auths` — registration, login, JWT strategy (`jwt.strategy.ts`), guard (`jwt-auth.guard.ts`)
+- `categories`, `transactions`, `budgets`, `dashboard` — domain modules, each with controller/service/dto
+- `shared` — exports `PrismaService` (extends `PrismaClient`) and `formatDecimal` utility; imported as `SharedModule` globally
+- `config` — env loading via `ConfigModule.forRoot`, Joi validation schema (`env.validation.ts`), typed config accessors
+- `common/filters` — global `HttpExceptionFilter`
+
+**Request flow:** Controller → `JwtAuthGuard` → Service → `PrismaService`
+
+**JWT payload:** `{ userId, email }` — controllers extract `userId` from the request user object to enforce per-user data isolation in every query.
+
+**Env file resolution** (in `app.module.ts`):
+- `NODE_ENV=test` → `.env.test`
+- `NODE_ENV=docker` → `.env.docker`
+- default → `.env`
+
+**`PrismaService`** has a safety guard: refuses to connect if `NODE_ENV=test` and the database URL doesn't look like a local/test database.
+
+**Monetary amounts** are stored as `Decimal(10,2)` in Postgres. Always use the `formatDecimal` helper from `modules/shared` when returning amounts to clients (converts Prisma `Decimal` to a plain `number`).
+
+**Swagger** is served at `/docs` (not `/api`).
+
+### Frontend (`apps/web`)
+
+**Next.js 15 App Router** with colocated page tests (`page.test.tsx`).
+
+**Auth:** `AuthContext` (`src/contexts/AuthContext.tsx`) stores the JWT in `localStorage`. User info is decoded client-side from the JWT payload.
+
+**API layer:**
+- `src/lib/api.ts` — `apiRequest` base function (fetch + Bearer token injection + error handling), exported as `api.get/post/put/delete`
+- `src/lib/categories.ts`, `transactions.ts`, `budgets.ts`, `dashboard.ts` — domain-specific API helpers built on `api`
+- `ApiException` is thrown for non-2xx responses, carrying `statusCode` and message
+
+**Testing stack:** Vitest + Testing Library + `msw` for HTTP mocking. MSW handlers live in `src/test/mocks/handlers.ts`; the server is set up in `src/test/setup.ts`.
+
+**UI:** shadcn/ui components in `src/components/ui/` (auto-generated, don't hand-edit). Feature components (`CategoryForm`, `TransactionForm`, `BudgetForm`, `BudgetDetails`) live directly in `src/components/`. Charts use `recharts` (PieChart, BarChart) in the dashboard page.
+
+**Post-login landing page:** `/dashboard` — authenticated users are redirected there from `/`.
+
+### Shared Package (`packages/shared`)
+Contains TypeScript interfaces (`ApiResponse`, `PaginatedResponse`, base entity types) and enums (`TransactionType`, `BudgetType`) used by both apps. Import as `@my-pocket/shared`.
+
+### Database Schema
+Four models in `prisma/schema.prisma`:
+- `User` — owns all other entities
+- `Category` — `(name, type, userId)` unique; type is `INCOME | EXPENSE`
+- `Transaction` — linked to a category; amount stored as `Decimal(10,2)`
+- `Budget` — `(categoryId, month, year, userId)` unique; tracks budget per category per month
+
+All data access is scoped by `userId`. Cascade deletes are set on all foreign keys.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },

--- a/apps/web/src/app/dashboard/page.test.tsx
+++ b/apps/web/src/app/dashboard/page.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mocks/server';
+import {
+  mockToken,
+  mockMonthlySummary,
+  mockCategoryBreakdown,
+  mockBudgetVsActual,
+  mockTopExpenses,
+} from '@/test/mocks/handlers';
+import { renderWithProviders, setupUser } from '@/test/test-utils';
+import DashboardPage from './page';
+
+const API_URL = 'http://localhost:3001';
+
+// Mock recharts to avoid SVG rendering issues in happy-dom
+vi.mock('recharts', () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: ({ data, nameKey }: { data: unknown[]; nameKey: unknown }) => (
+    <div data-testid="pie">{JSON.stringify(data)}</div>
+  ),
+  Cell: () => null,
+  BarChart: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: ({ dataKey }: { dataKey: string }) => (
+    <div data-testid={`bar-${dataKey}`}>{dataKey}</div>
+  ),
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// Mock next/navigation
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', async () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+  });
+
+  it('renders loading skeletons initially', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  it('renders monthly summary cards with correct values', async () => {
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Income')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    expect(screen.getByText('Total Expenses')).toBeInTheDocument();
+    // $150.00 appears in both the summary card and the top expenses table
+    expect(screen.getAllByText('$150.00').length).toBeGreaterThan(0);
+    expect(screen.getByText('Balance')).toBeInTheDocument();
+    expect(screen.getByText('$2,850.00')).toBeInTheDocument();
+  });
+
+  it('renders category breakdown section with category names', async () => {
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Category Breakdown')).toBeInTheDocument();
+    });
+
+    // Category breakdown data should be rendered in the pie chart
+    const pieChart = screen.getByTestId('pie-chart');
+    expect(pieChart).toBeInTheDocument();
+  });
+
+  it('renders budget vs actual section with category names', async () => {
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget vs Actual')).toBeInTheDocument();
+    });
+
+    const barChart = screen.getByTestId('bar-chart');
+    expect(barChart).toBeInTheDocument();
+    expect(screen.getByTestId('bar-Budget')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-Actual')).toBeInTheDocument();
+  });
+
+  it('renders top expenses table with expense rows', async () => {
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Top Expenses')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+    expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+    // Amount formatted as currency
+    const amounts = screen.getAllByText('$150.00');
+    expect(amounts.length).toBeGreaterThan(0);
+  });
+
+  it('clicking previous month decrements the month display', async () => {
+    const user = setupUser();
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Income')).toBeInTheDocument();
+    });
+
+    // The current date is mocked at March 2026 in the test environment
+    const prevBtn = screen.getByRole('button', { name: 'Previous month' });
+    await user.click(prevBtn);
+
+    // After clicking prev, the month label should change
+    // We just verify the button works (month navigation changes state)
+    await waitFor(() => {
+      // The month display should change (not March 2026 anymore or still loading)
+      const monthDisplay = screen.getByText(/\w+ \d{4}/);
+      expect(monthDisplay).toBeInTheDocument();
+    });
+  });
+
+  it('clicking next month increments the month display', async () => {
+    const user = setupUser();
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Income')).toBeInTheDocument();
+    });
+
+    const nextBtn = screen.getByRole('button', { name: 'Next month' });
+    await user.click(nextBtn);
+
+    await waitFor(() => {
+      const monthDisplay = screen.getByText(/\w+ \d{4}/);
+      expect(monthDisplay).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state when all endpoints return empty arrays', async () => {
+    server.use(
+      http.get(`${API_URL}/dashboard/monthly-summary`, () =>
+        HttpResponse.json({ totalIncome: 0, totalExpense: 0, balance: 0 }),
+      ),
+      http.get(`${API_URL}/dashboard/budget-vs-actual`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${API_URL}/dashboard/category-breakdown`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${API_URL}/dashboard/top-expenses`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No expenses for this period.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No category data for this period.')).toBeInTheDocument();
+    expect(screen.getByText('No budget data for this period.')).toBeInTheDocument();
+  });
+
+  it('renders balance in red when negative', async () => {
+    server.use(
+      http.get(`${API_URL}/dashboard/monthly-summary`, () =>
+        HttpResponse.json({
+          totalIncome: 100,
+          totalExpense: 500,
+          balance: -400,
+        }),
+      ),
+    );
+
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Balance')).toBeInTheDocument();
+    });
+
+    const balanceValue = screen.getByText('-$400.00');
+    expect(balanceValue).toHaveClass('text-red-600');
+  });
+
+  it('handles 401 error on any endpoint by logging out and redirecting', async () => {
+    server.use(
+      http.get(`${API_URL}/dashboard/monthly-summary`, () =>
+        HttpResponse.json(
+          { message: 'Unauthorized', statusCode: 401 },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('shows error state when monthly summary fails with 500', async () => {
+    server.use(
+      http.get(`${API_URL}/dashboard/monthly-summary`, () =>
+        HttpResponse.json(
+          { message: 'Server error', statusCode: 500 },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load monthly summary.'),
+      ).toBeInTheDocument();
+    });
+
+    // Other sections should still load
+    await waitFor(() => {
+      expect(screen.getByText('Top Expenses')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { dashboardApi } from '@/lib/dashboard';
+import {
+  MonthlySummary,
+  BudgetVsActual,
+  CategoryBreakdown,
+  TopExpense,
+} from '@/types';
+import { AuthLayout } from '@/components/layouts/AuthLayout';
+import { ApiException } from '@/lib/api';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+const COLORS = [
+  '#3b82f6',
+  '#ef4444',
+  '#10b981',
+  '#f59e0b',
+  '#8b5cf6',
+  '#06b6d4',
+];
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+}
+
+function formatMonthYear(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default function DashboardPage() {
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+  const [summary, setSummary] = useState<MonthlySummary | null>(null);
+  const [budgetVsActual, setBudgetVsActual] = useState<BudgetVsActual[]>([]);
+  const [categoryBreakdown, setCategoryBreakdown] = useState<
+    CategoryBreakdown[]
+  >([]);
+  const [topExpenses, setTopExpenses] = useState<TopExpense[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [summaryError, setSummaryError] = useState(false);
+  const { isAuthenticated, logout } = useAuth();
+  const router = useRouter();
+
+  const month = currentDate.getMonth() + 1;
+  const year = currentDate.getFullYear();
+
+  const goToPrev = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+  const goToNext = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    setIsLoading(true);
+    setSummaryError(false);
+
+    const handle401 = () => {
+      logout();
+      router.push('/login');
+    };
+
+    const summaryPromise = dashboardApi
+      .getMonthlySummary(month, year)
+      .then((data) => setSummary(data))
+      .catch((err) => {
+        if (err instanceof ApiException && err.statusCode === 401) {
+          handle401();
+          throw err;
+        }
+        setSummaryError(true);
+      });
+
+    const budgetPromise = dashboardApi
+      .getBudgetVsActual(month, year)
+      .then((data) => setBudgetVsActual(data))
+      .catch((err) => {
+        if (err instanceof ApiException && err.statusCode === 401) {
+          handle401();
+          throw err;
+        }
+        setBudgetVsActual([]);
+      });
+
+    const breakdownPromise = dashboardApi
+      .getCategoryBreakdown(month, year)
+      .then((data) => setCategoryBreakdown(data))
+      .catch((err) => {
+        if (err instanceof ApiException && err.statusCode === 401) {
+          handle401();
+          throw err;
+        }
+        setCategoryBreakdown([]);
+      });
+
+    const topExpensesPromise = dashboardApi
+      .getTopExpenses(month, year)
+      .then((data) => setTopExpenses(data))
+      .catch((err) => {
+        if (err instanceof ApiException && err.statusCode === 401) {
+          handle401();
+          throw err;
+        }
+        setTopExpenses([]);
+      });
+
+    Promise.allSettled([
+      summaryPromise,
+      budgetPromise,
+      breakdownPromise,
+      topExpensesPromise,
+    ]).finally(() => setIsLoading(false));
+  }, [isAuthenticated, month, year, logout, router]);
+
+  return (
+    <AuthLayout>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Dashboard</h2>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={goToPrev}
+            aria-label="Previous month"
+            className="p-1 rounded hover:bg-gray-100 text-gray-600"
+          >
+            ←
+          </button>
+          <span className="text-sm font-medium text-gray-700 min-w-[120px] text-center">
+            {formatMonthYear(currentDate)}
+          </span>
+          <button
+            onClick={goToNext}
+            aria-label="Next month"
+            className="p-1 rounded hover:bg-gray-100 text-gray-600"
+          >
+            →
+          </button>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="bg-white rounded-lg shadow p-6 animate-pulse"
+            >
+              <div className="h-4 bg-gray-200 rounded w-1/2 mb-3" />
+              <div className="h-8 bg-gray-200 rounded w-3/4" />
+            </div>
+          ))}
+        </div>
+      ) : summaryError ? (
+        <div className="bg-white rounded-lg shadow p-6 mb-6 text-center text-gray-500">
+          Failed to load monthly summary.
+        </div>
+      ) : summary ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-sm text-gray-500 mb-1">Total Income</p>
+            <p className="text-2xl font-bold text-green-600">
+              {formatCurrency(summary.totalIncome)}
+            </p>
+          </div>
+          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-sm text-gray-500 mb-1">Total Expenses</p>
+            <p className="text-2xl font-bold text-red-600">
+              {formatCurrency(summary.totalExpense)}
+            </p>
+          </div>
+          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-sm text-gray-500 mb-1">Balance</p>
+            <p
+              className={`text-2xl font-bold ${summary.balance >= 0 ? 'text-blue-600' : 'text-red-600'}`}
+            >
+              {formatCurrency(summary.balance)}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Charts Row */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          {[0, 1].map((i) => (
+            <div
+              key={i}
+              className="bg-white rounded-lg shadow p-6 animate-pulse"
+            >
+              <div className="h-4 bg-gray-200 rounded w-1/3 mb-4" />
+              <div className="h-48 bg-gray-200 rounded" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          {/* Category Breakdown Pie Chart */}
+          <div className="bg-white rounded-lg shadow p-6">
+            <h3 className="text-base font-semibold text-gray-900 mb-4">
+              Category Breakdown
+            </h3>
+            {categoryBreakdown.length === 0 ? (
+              <p className="text-gray-500 text-sm text-center py-8">
+                No category data for this period.
+              </p>
+            ) : (
+              <ResponsiveContainer width="100%" height={240}>
+                <PieChart>
+                  <Pie
+                    data={categoryBreakdown}
+                    dataKey="totalAmount"
+                    nameKey={(entry: CategoryBreakdown) => entry.category.name}
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    label={({ name, percentage }: { name: string; percentage: number }) =>
+                      `${name} ${percentage.toFixed(1)}%`
+                    }
+                  >
+                    {categoryBreakdown.map((_, index) => (
+                      <Cell
+                        key={index}
+                        fill={COLORS[index % COLORS.length]}
+                      />
+                    ))}
+                  </Pie>
+                  <Legend
+                    formatter={(value, entry) => {
+                      const item = categoryBreakdown.find(
+                        (c) => c.category.name === value,
+                      );
+                      return item ? item.category.name : value;
+                    }}
+                  />
+                  <Tooltip
+                    formatter={(value: number) => formatCurrency(value)}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+
+          {/* Budget vs Actual Bar Chart */}
+          <div className="bg-white rounded-lg shadow p-6">
+            <h3 className="text-base font-semibold text-gray-900 mb-4">
+              Budget vs Actual
+            </h3>
+            {budgetVsActual.length === 0 ? (
+              <p className="text-gray-500 text-sm text-center py-8">
+                No budget data for this period.
+              </p>
+            ) : (
+              <ResponsiveContainer width="100%" height={240}>
+                <BarChart
+                  data={budgetVsActual.map((b) => ({
+                    name: b.category.name,
+                    Budget: b.budget,
+                    Actual: b.actual,
+                  }))}
+                >
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <YAxis tick={{ fontSize: 12 }} />
+                  <Tooltip formatter={(value: number) => formatCurrency(value)} />
+                  <Legend />
+                  <Bar dataKey="Budget" fill="#3b82f6" />
+                  <Bar dataKey="Actual" fill="#ef4444" />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Top Expenses Table */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="p-6 border-b">
+          <h3 className="text-base font-semibold text-gray-900">
+            Top Expenses
+          </h3>
+        </div>
+        {isLoading ? (
+          <div className="p-6 animate-pulse">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex gap-4 mb-3">
+                <div className="h-4 bg-gray-200 rounded w-1/4" />
+                <div className="h-4 bg-gray-200 rounded w-1/4" />
+                <div className="h-4 bg-gray-200 rounded w-1/4" />
+                <div className="h-4 bg-gray-200 rounded w-1/4" />
+              </div>
+            ))}
+          </div>
+        ) : topExpenses.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">
+            No expenses for this period.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-gray-50">
+                <th className="px-6 py-3 text-left font-medium text-gray-500">
+                  Date
+                </th>
+                <th className="px-6 py-3 text-left font-medium text-gray-500">
+                  Category
+                </th>
+                <th className="px-6 py-3 text-left font-medium text-gray-500">
+                  Description
+                </th>
+                <th className="px-6 py-3 text-right font-medium text-gray-500">
+                  Amount
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {topExpenses.map((expense) => (
+                <tr key={expense.id} className="border-b last:border-0">
+                  <td className="px-6 py-4 text-gray-500">
+                    {formatDate(expense.date)}
+                  </td>
+                  <td className="px-6 py-4 font-medium">
+                    {expense.category.name}
+                  </td>
+                  <td className="px-6 py-4 text-gray-500">
+                    {expense.description ?? '—'}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium text-red-600">
+                    {formatCurrency(expense.amount)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
-      router.push('/categories');
+      router.push('/dashboard');
     }
   }, [isLoading, isAuthenticated, router]);
 

--- a/apps/web/src/components/layouts/AuthLayout.tsx
+++ b/apps/web/src/components/layouts/AuthLayout.tsx
@@ -33,10 +33,16 @@ export function AuthLayout({ children }: AuthLayoutProps) {
       <header className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <div className="flex items-center gap-8">
-            <Link href="/categories">
+            <Link href="/dashboard">
               <h1 className="text-2xl font-bold text-gray-900">My Pocket</h1>
             </Link>
             <nav className="flex items-center gap-4">
+              <Link
+                href="/dashboard"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+              >
+                Dashboard
+              </Link>
               <Link
                 href="/categories"
                 className="text-sm font-medium text-gray-600 hover:text-gray-900"

--- a/apps/web/src/lib/dashboard.ts
+++ b/apps/web/src/lib/dashboard.ts
@@ -1,0 +1,29 @@
+import { api } from '@/lib/api';
+import type {
+  MonthlySummary,
+  BudgetVsActual,
+  CategoryBreakdown,
+  TopExpense,
+} from '@/types';
+
+export const dashboardApi = {
+  getMonthlySummary: (month: number, year: number) =>
+    api.get<MonthlySummary>(
+      `/dashboard/monthly-summary?month=${month}&year=${year}`,
+    ),
+
+  getBudgetVsActual: (month: number, year: number) =>
+    api.get<BudgetVsActual[]>(
+      `/dashboard/budget-vs-actual?month=${month}&year=${year}`,
+    ),
+
+  getCategoryBreakdown: (month: number, year: number) =>
+    api.get<CategoryBreakdown[]>(
+      `/dashboard/category-breakdown?month=${month}&year=${year}`,
+    ),
+
+  getTopExpenses: (month: number, year: number, limit = 5) =>
+    api.get<TopExpense[]>(
+      `/dashboard/top-expenses?month=${month}&year=${year}&limit=${limit}`,
+    ),
+};

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -112,6 +112,57 @@ export const mockBudgetsWithSpending = [
   },
 ];
 
+// Dashboard mock data
+export const mockMonthlySummary = {
+  totalIncome: 3000,
+  totalExpense: 150,
+  balance: 2850,
+};
+
+export const mockBudgetVsActual = [
+  {
+    categoryId: 'cat-2',
+    category: { id: 'cat-2', name: 'Groceries', type: 'EXPENSE' },
+    budget: 500,
+    actual: 150,
+    difference: 350,
+    percentageUsed: 30,
+  },
+  {
+    categoryId: 'cat-1',
+    category: { id: 'cat-1', name: 'Salary', type: 'INCOME' },
+    budget: 3000,
+    actual: 3000,
+    difference: 0,
+    percentageUsed: 100,
+  },
+];
+
+export const mockCategoryBreakdown = [
+  {
+    categoryId: 'cat-1',
+    category: { id: 'cat-1', name: 'Salary', type: 'INCOME' },
+    totalAmount: 3000,
+    percentage: 95.24,
+  },
+  {
+    categoryId: 'cat-2',
+    category: { id: 'cat-2', name: 'Groceries', type: 'EXPENSE' },
+    totalAmount: 150,
+    percentage: 4.76,
+  },
+];
+
+export const mockTopExpenses = [
+  {
+    id: 'transaction-1',
+    description: 'Grocery shopping',
+    date: '2026-03-01T10:00:00.000Z',
+    amount: 150,
+    category: { id: 'cat-2', name: 'Groceries', type: 'EXPENSE' },
+  },
+];
+
 // Generate a valid-looking JWT for testing
 export const mockToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZXN0LXVzZXItaWQiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJuYW1lIjoiVGVzdCBVc2VyIiwiaWF0IjoxNzA0MDY3MjAwfQ.fake-signature';
@@ -378,6 +429,51 @@ export const handlers = [
       );
     }
     return new HttpResponse(null, { status: 204 });
+  }),
+
+  // Dashboard endpoints
+  http.get(`${API_URL}/dashboard/monthly-summary`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json(mockMonthlySummary);
+  }),
+
+  http.get(`${API_URL}/dashboard/budget-vs-actual`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json(mockBudgetVsActual);
+  }),
+
+  http.get(`${API_URL}/dashboard/category-breakdown`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json(mockCategoryBreakdown);
+  }),
+
+  http.get(`${API_URL}/dashboard/top-expenses`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json(mockTopExpenses);
   }),
 
   // Transactions endpoints

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -153,3 +153,34 @@ export interface ApiError {
   message: string;
   statusCode: number;
 }
+
+// Dashboard types
+export interface MonthlySummary {
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+}
+
+export interface BudgetVsActual {
+  categoryId: string;
+  category: { id: string; name: string; type: CategoryType };
+  budget: number;
+  actual: number;
+  difference: number;
+  percentageUsed: number;
+}
+
+export interface CategoryBreakdown {
+  categoryId: string;
+  category: { id: string; name: string; type: CategoryType };
+  totalAmount: number;
+  percentage: number;
+}
+
+export interface TopExpense {
+  id: string;
+  description: string | null;
+  date: string;
+  amount: number;
+  category: { id: string; name: string; type: CategoryType };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
@@ -5799,6 +5800,42 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -6199,8 +6236,13 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -6787,6 +6829,69 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -7022,6 +7127,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -9066,6 +9177,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -9109,6 +9341,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -9474,6 +9712,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -9761,6 +10009,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -10325,7 +10579,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10814,6 +11067,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10882,6 +11145,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -14003,8 +14275,30 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -14132,6 +14426,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -14143,6 +14467,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -14167,6 +14506,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -15640,8 +15985,7 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -16429,6 +16773,28 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {


### PR DESCRIPTION
- Add /dashboard page with monthly summary cards, category breakdown pie chart, budget vs actual bar chart, and top expenses table
- Add month/year navigator to browse historical data
- Redirect authenticated users from / to /dashboard
- Add Dashboard nav link to AuthLayout; update logo href to /dashboard
- Add recharts dependency for charts
- Add dashboard types, API helper, MSW mock handlers, and page tests
- Update CLAUDE.md to document new dashboard module