### PR TITLE
fix(web): replace hardcoded colors with semantic tokens for dark mode

### DIFF
--- a/apps/web/src/app/budgets/[id]/page.tsx
+++ b/apps/web/src/app/budgets/[id]/page.tsx
@@ -85,7 +85,7 @@ export default function BudgetDetailsPage() {
   return (
     <AuthLayout>
       <div className="max-w-3xl mx-auto">
-        <h2 className="text-xl font-semibold text-gray-900 mb-6">
+        <h2 className="text-xl font-semibold text-foreground mb-6">
           Budget Details
         </h2>
         {isLoading ? (

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -103,15 +103,13 @@ function getUtilizationColor(
 ): string {
   if (percentage === undefined) return '';
   if (budgetType === BudgetType.INCOME) {
-    // For INCOME: higher percentage is better (more earned toward goal)
-    if (percentage >= 75) return 'text-green-600';
-    if (percentage >= 50) return 'text-yellow-600';
-    return 'text-red-600';
+    if (percentage >= 75) return 'text-green-600 dark:text-green-400';
+    if (percentage >= 50) return 'text-yellow-600 dark:text-yellow-400';
+    return 'text-red-600 dark:text-red-400';
   }
-  // For EXPENSE: lower percentage is better (less spent)
-  if (percentage >= 100) return 'text-red-600';
-  if (percentage >= 75) return 'text-yellow-600';
-  return 'text-green-600';
+  if (percentage >= 100) return 'text-red-600 dark:text-red-400';
+  if (percentage >= 75) return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-green-600 dark:text-green-400';
 }
 
 export default function BudgetsPage() {
@@ -250,7 +248,7 @@ export default function BudgetsPage() {
   return (
     <AuthLayout>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Budgets</h2>
+        <h2 className="text-xl font-semibold text-foreground">Budgets</h2>
         <Link href="/budgets/new">
           <Button>New Budget</Button>
         </Link>
@@ -333,15 +331,15 @@ export default function BudgetsPage() {
         </p>
       )}
 
-      <div className="bg-white rounded-lg shadow">
+      <div className="bg-card rounded-lg shadow">
         {isLoading ? (
           <BudgetsTableSkeleton />
         ) : budgets.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No budgets yet. Create your first budget to get started.
           </div>
         ) : filteredBudgets.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No budgets match your filters.
           </div>
         ) : (
@@ -381,7 +379,7 @@ export default function BudgetsPage() {
                         <TableCell
                           className={
                             parseFloat(budget.remaining || '0') < 0
-                              ? 'text-red-600'
+                              ? 'text-red-600 dark:text-red-400'
                               : ''
                           }
                         >
@@ -394,15 +392,15 @@ export default function BudgetsPage() {
                         </TableCell>
                       </>
                     )}
-                    <TableCell className="text-gray-500">
+                    <TableCell className="text-muted-foreground">
                       {formatPeriod(budget.month, budget.year)}
                     </TableCell>
                     <TableCell>
                       <span
                         className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                           budget.type === 'INCOME'
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-red-100 text-red-800'
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
                         }`}
                       >
                         {budget.type}

--- a/apps/web/src/app/categories/page.tsx
+++ b/apps/web/src/app/categories/page.tsx
@@ -107,7 +107,7 @@ export default function CategoriesPage() {
   return (
     <AuthLayout>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Categories</h2>
+        <h2 className="text-xl font-semibold text-foreground">Categories</h2>
         <Link href="/categories/new">
           <Button>New Category</Button>
         </Link>
@@ -135,15 +135,15 @@ export default function CategoriesPage() {
         </Select>
       </div>
 
-      <div className="bg-white rounded-lg shadow">
+      <div className="bg-card rounded-lg shadow">
         {isLoading ? (
           <CategoriesTableSkeleton />
         ) : categories.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No categories yet. Create your first category to get started.
           </div>
         ) : filteredCategories.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No categories match your search.
           </div>
         ) : (
@@ -164,14 +164,14 @@ export default function CategoriesPage() {
                     <span
                       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                         category.type === 'INCOME'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-red-100 text-red-800'
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
                       }`}
                     >
                       {category.type}
                     </span>
                   </TableCell>
-                  <TableCell className="text-gray-500">
+                  <TableCell className="text-muted-foreground">
                     {new Date(category.createdAt).toLocaleDateString()}
                   </TableCell>
                   <TableCell className="text-right space-x-2">

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -142,22 +142,22 @@ export default function DashboardPage() {
     <AuthLayout>
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Dashboard</h2>
+        <h2 className="text-xl font-semibold text-foreground">Dashboard</h2>
         <div className="flex items-center gap-2">
           <button
             onClick={goToPrev}
             aria-label="Previous month"
-            className="p-1 rounded hover:bg-gray-100 text-gray-600"
+            className="p-1 rounded hover:bg-muted text-muted-foreground"
           >
             ←
           </button>
-          <span className="text-sm font-medium text-gray-700 min-w-[120px] text-center">
+          <span className="text-sm font-medium text-foreground min-w-[120px] text-center">
             {formatMonthYear(currentDate)}
           </span>
           <button
             onClick={goToNext}
             aria-label="Next month"
-            className="p-1 rounded hover:bg-gray-100 text-gray-600"
+            className="p-1 rounded hover:bg-muted text-muted-foreground"
           >
             →
           </button>
@@ -170,35 +170,35 @@ export default function DashboardPage() {
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="bg-white rounded-lg shadow p-6 animate-pulse"
+              className="bg-card rounded-lg shadow p-6 animate-pulse"
             >
-              <div className="h-4 bg-gray-200 rounded w-1/2 mb-3" />
-              <div className="h-8 bg-gray-200 rounded w-3/4" />
+              <div className="h-4 bg-muted rounded w-1/2 mb-3" />
+              <div className="h-8 bg-muted rounded w-3/4" />
             </div>
           ))}
         </div>
       ) : summaryError ? (
-        <div className="bg-white rounded-lg shadow p-6 mb-6 text-center text-gray-500">
+        <div className="bg-card rounded-lg shadow p-6 mb-6 text-center text-muted-foreground">
           Failed to load monthly summary.
         </div>
       ) : summary ? (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-          <div className="bg-white rounded-lg shadow p-6">
-            <p className="text-sm text-gray-500 mb-1">Total Income</p>
-            <p className="text-2xl font-bold text-green-600">
+          <div className="bg-card rounded-lg shadow p-6">
+            <p className="text-sm text-muted-foreground mb-1">Total Income</p>
+            <p className="text-2xl font-bold text-green-600 dark:text-green-400">
               {formatCurrency(summary.totalIncome)}
             </p>
           </div>
-          <div className="bg-white rounded-lg shadow p-6">
-            <p className="text-sm text-gray-500 mb-1">Total Expenses</p>
-            <p className="text-2xl font-bold text-red-600">
+          <div className="bg-card rounded-lg shadow p-6">
+            <p className="text-sm text-muted-foreground mb-1">Total Expenses</p>
+            <p className="text-2xl font-bold text-red-600 dark:text-red-400">
               {formatCurrency(summary.totalExpense)}
             </p>
           </div>
-          <div className="bg-white rounded-lg shadow p-6">
-            <p className="text-sm text-gray-500 mb-1">Balance</p>
+          <div className="bg-card rounded-lg shadow p-6">
+            <p className="text-sm text-muted-foreground mb-1">Balance</p>
             <p
-              className={`text-2xl font-bold ${summary.balance >= 0 ? 'text-blue-600' : 'text-red-600'}`}
+              className={`text-2xl font-bold ${summary.balance >= 0 ? 'text-blue-600 dark:text-blue-400' : 'text-red-600 dark:text-red-400'}`}
             >
               {formatCurrency(summary.balance)}
             </p>
@@ -212,22 +212,22 @@ export default function DashboardPage() {
           {[0, 1].map((i) => (
             <div
               key={i}
-              className="bg-white rounded-lg shadow p-6 animate-pulse"
+              className="bg-card rounded-lg shadow p-6 animate-pulse"
             >
-              <div className="h-4 bg-gray-200 rounded w-1/3 mb-4" />
-              <div className="h-48 bg-gray-200 rounded" />
+              <div className="h-4 bg-muted rounded w-1/3 mb-4" />
+              <div className="h-48 bg-muted rounded" />
             </div>
           ))}
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
           {/* Category Breakdown Pie Chart */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-4">
+          <div className="bg-card rounded-lg shadow p-6">
+            <h3 className="text-base font-semibold text-foreground mb-4">
               Category Breakdown
             </h3>
             {categoryBreakdown.length === 0 ? (
-              <p className="text-gray-500 text-sm text-center py-8">
+              <p className="text-muted-foreground text-sm text-center py-8">
                 No category data for this period.
               </p>
             ) : (
@@ -268,12 +268,12 @@ export default function DashboardPage() {
           </div>
 
           {/* Budget vs Actual Bar Chart */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-4">
+          <div className="bg-card rounded-lg shadow p-6">
+            <h3 className="text-base font-semibold text-foreground mb-4">
               Budget vs Actual
             </h3>
             {budgetVsActual.length === 0 ? (
-              <p className="text-gray-500 text-sm text-center py-8">
+              <p className="text-muted-foreground text-sm text-center py-8">
                 No budget data for this period.
               </p>
             ) : (
@@ -300,9 +300,9 @@ export default function DashboardPage() {
       )}
 
       {/* Top Expenses Table */}
-      <div className="bg-white rounded-lg shadow">
+      <div className="bg-card rounded-lg shadow">
         <div className="p-6 border-b">
-          <h3 className="text-base font-semibold text-gray-900">
+          <h3 className="text-base font-semibold text-foreground">
             Top Expenses
           </h3>
         </div>
@@ -310,31 +310,31 @@ export default function DashboardPage() {
           <div className="p-6 animate-pulse">
             {[0, 1, 2, 3, 4].map((i) => (
               <div key={i} className="flex gap-4 mb-3">
-                <div className="h-4 bg-gray-200 rounded w-1/4" />
-                <div className="h-4 bg-gray-200 rounded w-1/4" />
-                <div className="h-4 bg-gray-200 rounded w-1/4" />
-                <div className="h-4 bg-gray-200 rounded w-1/4" />
+                <div className="h-4 bg-muted rounded w-1/4" />
+                <div className="h-4 bg-muted rounded w-1/4" />
+                <div className="h-4 bg-muted rounded w-1/4" />
+                <div className="h-4 bg-muted rounded w-1/4" />
               </div>
             ))}
           </div>
         ) : topExpenses.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No expenses for this period.
           </div>
         ) : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b bg-gray-50">
-                <th className="px-6 py-3 text-left font-medium text-gray-500">
+              <tr className="border-b bg-muted/50">
+                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
                   Date
                 </th>
-                <th className="px-6 py-3 text-left font-medium text-gray-500">
+                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
                   Category
                 </th>
-                <th className="px-6 py-3 text-left font-medium text-gray-500">
+                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
                   Description
                 </th>
-                <th className="px-6 py-3 text-right font-medium text-gray-500">
+                <th className="px-6 py-3 text-right font-medium text-muted-foreground">
                   Amount
                 </th>
               </tr>
@@ -342,16 +342,16 @@ export default function DashboardPage() {
             <tbody>
               {topExpenses.map((expense) => (
                 <tr key={expense.id} className="border-b last:border-0">
-                  <td className="px-6 py-4 text-gray-500">
+                  <td className="px-6 py-4 text-muted-foreground">
                     {formatDate(expense.date)}
                   </td>
                   <td className="px-6 py-4 font-medium">
                     {expense.category.name}
                   </td>
-                  <td className="px-6 py-4 text-gray-500">
+                  <td className="px-6 py-4 text-muted-foreground">
                     {expense.description ?? '—'}
                   </td>
-                  <td className="px-6 py-4 text-right font-medium text-red-600">
+                  <td className="px-6 py-4 text-right font-medium text-red-600 dark:text-red-400">
                     {formatCurrency(expense.amount)}
                   </td>
                 </tr>

--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -53,7 +53,7 @@ describe('LoginPage', () => {
     expect(signUpLink).toHaveAttribute('href', '/register');
   });
 
-  it('successful login shows success toast and redirects to categories', async () => {
+  it('successful login shows success toast and redirects to dashboard', async () => {
     const user = userEvent.setup();
     const { toast } = await import('sonner');
 
@@ -67,7 +67,7 @@ describe('LoginPage', () => {
       expect(toast.success).toHaveBeenCalledWith('Login successful!');
     });
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
   });
 
   it('shows error toast with API message on invalid credentials', async () => {

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -87,7 +87,7 @@ export default function LoginPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   disabled={isLoading}
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
@@ -104,7 +104,7 @@ export default function LoginPage() {
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'Signing in...' : 'Sign in'}
             </Button>
-            <p className="text-sm text-gray-600 text-center">
+            <p className="text-sm text-muted-foreground text-center">
               Don&apos;t have an account?{' '}
               <Link href="/register" className="text-primary hover:underline">
                 Sign up

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,16 +19,16 @@ export default function Home() {
   if (isLoading) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center p-24">
-        <p className="text-gray-500">Loading...</p>
+        <p className="text-muted-foreground">Loading...</p>
       </main>
     );
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24 bg-gray-50">
+    <main className="flex min-h-screen flex-col items-center justify-center p-24 bg-background">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">My Pocket</h1>
-        <p className="text-lg text-gray-600 mb-8">
+        <p className="text-lg text-muted-foreground mb-8">
           Personal Finance Management
         </p>
         <div className="flex gap-4 justify-center">

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -80,7 +80,7 @@ describe('RegisterPage', () => {
       );
     });
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
   });
 
   it('shows error toast when email already exists', async () => {

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -101,7 +101,7 @@ export default function RegisterPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   disabled={isLoading}
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
@@ -118,7 +118,7 @@ export default function RegisterPage() {
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'Creating account...' : 'Create account'}
             </Button>
-            <p className="text-sm text-gray-600 text-center">
+            <p className="text-sm text-muted-foreground text-center">
               Already have an account?{' '}
               <Link href="/login" className="text-primary hover:underline">
                 Sign in

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -180,7 +180,7 @@ export default function TransactionsPage() {
   return (
     <AuthLayout>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Transactions</h2>
+        <h2 className="text-xl font-semibold text-foreground">Transactions</h2>
         <Link href="/transactions/new">
           <Button>New Transaction</Button>
         </Link>
@@ -245,15 +245,15 @@ export default function TransactionsPage() {
         </Button>
       </div>
 
-      <div className="bg-white rounded-lg shadow">
+      <div className="bg-card rounded-lg shadow">
         {isLoading ? (
           <TransactionsTableSkeleton />
         ) : transactions.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No transactions yet. Create your first transaction to get started.
           </div>
         ) : filteredTransactions.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-muted-foreground">
             No transactions match your filters.
           </div>
         ) : (
@@ -271,7 +271,7 @@ export default function TransactionsPage() {
             <TableBody>
               {filteredTransactions.map((transaction) => (
                 <TableRow key={transaction.id}>
-                  <TableCell className="text-gray-500">
+                  <TableCell className="text-muted-foreground">
                     {formatDate(transaction.date)}
                   </TableCell>
                   <TableCell className="font-medium">
@@ -284,8 +284,8 @@ export default function TransactionsPage() {
                     <span
                       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                         transaction.type === 'INCOME'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-red-100 text-red-800'
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
                       }`}
                     >
                       {transaction.type}

--- a/apps/web/src/components/BudgetDetails.tsx
+++ b/apps/web/src/components/BudgetDetails.tsx
@@ -81,15 +81,13 @@ function getUtilizationTextColor(
   budgetType: BudgetType,
 ): string {
   if (budgetType === BudgetType.INCOME) {
-    // For INCOME: higher percentage is better
-    if (percentage >= 75) return 'text-green-600';
-    if (percentage >= 50) return 'text-yellow-600';
-    return 'text-red-600';
+    if (percentage >= 75) return 'text-green-600 dark:text-green-400';
+    if (percentage >= 50) return 'text-yellow-600 dark:text-yellow-400';
+    return 'text-red-600 dark:text-red-400';
   }
-  // For EXPENSE: lower percentage is better
-  if (percentage >= 100) return 'text-red-600';
-  if (percentage >= 75) return 'text-yellow-600';
-  return 'text-green-600';
+  if (percentage >= 100) return 'text-red-600 dark:text-red-400';
+  if (percentage >= 75) return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-green-600 dark:text-green-400';
 }
 
 function getProgressValue(budget: BudgetWithDetails): string {
@@ -130,8 +128,8 @@ export function BudgetDetails({ budget }: BudgetDetailsProps) {
             <span
               className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                 budget.type === BudgetType.INCOME
-                  ? 'bg-green-100 text-green-800'
-                  : 'bg-red-100 text-red-800'
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                  : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
               }`}
               data-testid="budget-type-badge"
             >
@@ -160,7 +158,7 @@ export function BudgetDetails({ budget }: BudgetDetailsProps) {
               </span>
             </div>
             <div
-              className="h-3 w-full rounded-full bg-gray-200 overflow-hidden"
+              className="h-3 w-full rounded-full bg-muted overflow-hidden"
               data-testid="progress-bar-container"
             >
               <div
@@ -173,22 +171,22 @@ export function BudgetDetails({ budget }: BudgetDetailsProps) {
 
           {/* Spent/Earned and Remaining */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="p-4 rounded-lg bg-gray-50">
+            <div className="p-4 rounded-lg bg-muted/50">
               <p className="text-sm text-muted-foreground">{progressLabel}</p>
               <p
-                className="text-lg font-semibold text-gray-900"
+                className="text-lg font-semibold text-foreground"
                 data-testid="budget-progress-value"
               >
                 {formatAmount(progressValue)}
               </p>
             </div>
-            <div className="p-4 rounded-lg bg-gray-50">
+            <div className="p-4 rounded-lg bg-muted/50">
               <p className="text-sm text-muted-foreground">Remaining</p>
               <p
                 className={`text-lg font-semibold ${
                   parseFloat(budget.remaining) < 0
-                    ? 'text-red-600'
-                    : 'text-gray-900'
+                    ? 'text-red-600 dark:text-red-400'
+                    : 'text-foreground'
                 }`}
                 data-testid="budget-remaining"
               >

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -46,11 +46,11 @@ export class ErrorBoundary extends Component<
   render(): ReactNode {
     if (this.state.hasError) {
       return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="min-h-screen flex items-center justify-center bg-background px-4">
           <Card className="w-full max-w-md">
             <CardHeader className="text-center">
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
-                <AlertTriangle className="h-6 w-6 text-red-600" />
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+                <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
               </div>
               <CardTitle className="text-2xl font-bold">
                 Something went wrong
@@ -62,8 +62,8 @@ export class ErrorBoundary extends Component<
             </CardHeader>
             {this.state.error && (
               <CardContent>
-                <div className="rounded-md bg-gray-100 p-3">
-                  <p className="text-sm text-gray-600 font-mono break-all">
+                <div className="rounded-md bg-muted p-3">
+                  <p className="text-sm text-muted-foreground font-mono break-all">
                     {this.state.error.message}
                   </p>
                 </div>

--- a/apps/web/src/components/layouts/AuthLayout.tsx
+++ b/apps/web/src/components/layouts/AuthLayout.tsx
@@ -24,7 +24,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
   if (isLoading || !isAuthenticated) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-500">Loading...</p>
+        <p className="text-muted-foreground">Loading...</p>
       </div>
     );
   }
@@ -35,30 +35,30 @@ export function AuthLayout({ children }: AuthLayoutProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <div className="flex items-center gap-8">
             <Link href="/dashboard">
-              <h1 className="text-2xl font-bold text-gray-900">My Pocket</h1>
+              <h1 className="text-2xl font-bold text-foreground">My Pocket</h1>
             </Link>
             <nav className="flex items-center gap-4">
               <Link
                 href="/dashboard"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground"
               >
                 Dashboard
               </Link>
               <Link
                 href="/categories"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground"
               >
                 Categories
               </Link>
               <Link
                 href="/budgets"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground"
               >
                 Budgets
               </Link>
               <Link
                 href="/transactions"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground"
               >
                 Transactions
               </Link>


### PR DESCRIPTION
Replace all hardcoded Tailwind gray/white/color classes across pages and components with semantic CSS variables (text-foreground, text-muted-foreground, bg-background, bg-card, bg-muted, border-border) so every element respects the active theme.

- Add dark: variants to status colors (green/red/yellow/blue) in badges, financial amounts, progress bars, and utilization indicators
- Fix type badge bg/text for INCOME/EXPENSE across categories, transactions, budgets, and BudgetDetails
- Update AuthLayout nav links, header logo, and loading state
- Update ErrorBoundary, home page, login, and register pages
- Fix redirect assertions in login/register tests to match /dashboard