### PR TITLE
docs: update README and CLAUDE.md for dark mode and recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ This is a **Turborepo + npm workspaces** monorepo:
 **NestJS modular architecture** under `src/modules/`:
 - `auths` — registration, login, JWT strategy (`jwt.strategy.ts`), guard (`jwt-auth.guard.ts`)
 - `categories`, `transactions`, `budgets`, `dashboard` — domain modules, each with controller/service/dto
+- `health` — single `GET /health` endpoint for service availability checks
 - `shared` — exports `PrismaService` (extends `PrismaClient`) and `formatDecimal` utility; imported as `SharedModule` globally
 - `config` — env loading via `ConfigModule.forRoot`, Joi validation schema (`env.validation.ts`), typed config accessors
 - `common/filters` — global `HttpExceptionFilter`
@@ -95,9 +96,13 @@ This is a **Turborepo + npm workspaces** monorepo:
 
 **Testing stack:** Vitest + Testing Library + `msw` for HTTP mocking. MSW handlers live in `src/test/mocks/handlers.ts`; the server is set up in `src/test/setup.ts`.
 
-**UI:** shadcn/ui components in `src/components/ui/` (auto-generated, don't hand-edit). Feature components (`CategoryForm`, `TransactionForm`, `BudgetForm`, `BudgetDetails`) live directly in `src/components/`. Charts use `recharts` (PieChart, BarChart) in the dashboard page.
+**Theme:** `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) wraps the root layout and wires up `next-themes` with `attribute="class"`. The `ThemeToggle` component (`src/components/ThemeToggle.tsx`) renders a dropdown (Light / Dark / System) in the `AuthLayout` header. All page backgrounds and text use semantic Tailwind tokens (`bg-background`, `text-foreground`, `text-muted-foreground`, etc.) so they respond to the active theme.
 
-**Post-login landing page:** `/dashboard` — authenticated users are redirected there from `/`.
+**Error handling:** `ErrorBoundary` (`src/components/ErrorBoundary.tsx`) is a React class component wrapping the entire app in `layout.tsx`. It catches unhandled render errors and shows a recovery UI with a "Try Again" button.
+
+**UI:** shadcn/ui components in `src/components/ui/` (auto-generated, don't hand-edit). Feature components (`CategoryForm`, `TransactionForm`, `BudgetForm`, `BudgetDetails`, `ThemeToggle`) live directly in `src/components/`. Charts use `recharts` (PieChart, BarChart) in the dashboard page.
+
+**Post-login landing page:** `/dashboard` — authenticated users are redirected there from `/` and after login/registration.
 
 ### Shared Package (`packages/shared`)
 Contains TypeScript interfaces (`ApiResponse`, `PaginatedResponse`, base entity types) and enums (`TransactionType`, `BudgetType`) used by both apps. Import as `@my-pocket/shared`.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ my-pocket/
 - **UI Components:** shadcn/ui, Radix UI
 - **Icons:** Lucide React
 - **Notifications:** Sonner
+- **Charts:** Recharts
+- **Theme:** next-themes (Light / Dark / System)
 - **Bundler:** Turbopack
-- **Testing:** Vitest + Testing Library
+- **Testing:** Vitest + Testing Library + MSW
 
 ### Shared (packages/shared)
 
@@ -244,7 +246,7 @@ npm run docker:prod:down
 
 Once the API is running, visit:
 
-- **Swagger UI:** http://localhost:3001/api
+- **Swagger UI:** http://localhost:3001/docs
 
 ### API Endpoints Summary
 
@@ -277,8 +279,9 @@ Once the API is running, visit:
 
 ---
 
-## 📋 API Features
+## 📋 Features
 
+### API
 - ✅ User registration and authentication with JWT
 - ✅ Protected routes with authentication guards
 - ✅ Categories, Transactions, and Budgets management
@@ -287,7 +290,15 @@ Once the API is running, visit:
 - ✅ Strict per-user data isolation
 - ✅ Comprehensive validation using DTOs
 - ✅ Global exception handling
-- ✅ Interactive API documentation (Swagger/OpenAPI)
+- ✅ Interactive API documentation (Swagger/OpenAPI at `/docs`)
+
+### Frontend
+- ✅ Dashboard as post-login landing page with charts and monthly summary
+- ✅ Dark / Light / System theme toggle (persisted via `localStorage`)
+- ✅ Full CRUD for Categories, Transactions, and Budgets
+- ✅ Budget spending tracking with utilization indicators
+- ✅ Responsive design with shadcn/ui components
+- ✅ Error boundary with recovery UI
 
 ---
 


### PR DESCRIPTION
README.md:
- Add recharts and next-themes to frontend tech stack
- Add MSW to testing stack entry
- Fix Swagger URL from /api to /docs
- Split API Features into API + Frontend sections, adding dark mode theme toggle, dashboard landing page, and error boundary entries

CLAUDE.md:
- Add health module to backend module list
- Document ThemeProvider, ThemeToggle, and next-themes theme setup
- Document ErrorBoundary component and its role in the app layout
- Clarify post-login redirect includes login and registration flows