### PR TITLE
fix(security): add DTO maxlength, password complexity, and refresh to…

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -9,7 +9,8 @@ NODE_ENV=production
 
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-JWT_EXPIRATION=3600
+JWT_EXPIRATION=900
+JWT_REFRESH_EXPIRATION=604800
 
 # Application Port
 PORT=3000

--- a/apps/api/src/i18n/en/auth.json
+++ b/apps/api/src/i18n/en/auth.json
@@ -1,6 +1,7 @@
 {
   "errors": {
     "emailAlreadyExists": "Email already exists",
-    "invalidCredentials": "Invalid credentials"
+    "invalidCredentials": "Invalid credentials",
+    "invalidRefreshToken": "Invalid or expired refresh token"
   }
 }

--- a/apps/api/src/i18n/en/validation.json
+++ b/apps/api/src/i18n/en/validation.json
@@ -9,5 +9,6 @@
   "min": "{property} must not be less than {constraints.0}",
   "max": "{property} must not be greater than {constraints.0}",
   "isDateString": "{property} must be a valid ISO 8601 date string",
-  "isOptional": "{property} is optional"
+  "isOptional": "{property} is optional",
+  "passwordComplexity": "Password must contain at least one uppercase letter, one lowercase letter, and one number"
 }

--- a/apps/api/src/i18n/pt-BR/auth.json
+++ b/apps/api/src/i18n/pt-BR/auth.json
@@ -1,6 +1,7 @@
 {
   "errors": {
     "emailAlreadyExists": "Email já cadastrado",
-    "invalidCredentials": "Credenciais inválidas"
+    "invalidCredentials": "Credenciais inválidas",
+    "invalidRefreshToken": "Token de atualização inválido ou expirado"
   }
 }

--- a/apps/api/src/i18n/pt-BR/validation.json
+++ b/apps/api/src/i18n/pt-BR/validation.json
@@ -9,5 +9,6 @@
   "min": "{property} não pode ser menor que {constraints.0}",
   "max": "{property} não pode ser maior que {constraints.0}",
   "isDateString": "{property} deve ser uma data ISO 8601 válida",
-  "isOptional": "{property} é opcional"
+  "isOptional": "{property} é opcional",
+  "passwordComplexity": "A senha deve conter pelo menos uma letra maiúscula, uma letra minúscula e um número"
 }

--- a/apps/api/src/modules/auths/auths.controller.ts
+++ b/apps/api/src/modules/auths/auths.controller.ts
@@ -1,10 +1,20 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { AuthsService } from './auths.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { RefreshDto } from './dto/refresh.dto';
 import { AuthResponseDto } from './dto/auth-response.dto';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @ApiTags('auth')
 @Controller('auths')
@@ -43,5 +53,33 @@ export class AuthsController {
   })
   async login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
     return this.authsService.login(loginDto);
+  }
+
+  @Post('refresh')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Exchange a refresh token for new tokens' })
+  @ApiBody({ type: RefreshDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Tokens refreshed successfully',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Invalid or expired refresh token' })
+  async refresh(@Body() refreshDto: RefreshDto): Promise<AuthResponseDto> {
+    return this.authsService.refresh(refreshDto.refresh_token);
+  }
+
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Logout and invalidate the refresh token' })
+  @ApiResponse({ status: 200, description: 'Logged out successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async logout(
+    @Req() req: { user: { userId: string } },
+  ): Promise<{ message: string }> {
+    await this.authsService.logout(req.user.userId);
+    return { message: 'Logged out successfully' };
   }
 }

--- a/apps/api/src/modules/auths/auths.module.ts
+++ b/apps/api/src/modules/auths/auths.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+
 import { AuthsService } from './auths.service';
 import { AuthsController } from './auths.controller';
 import { SharedModule } from '../shared/shared.module';

--- a/apps/api/src/modules/auths/auths.service.spec.ts
+++ b/apps/api/src/modules/auths/auths.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { I18nService } from 'nestjs-i18n';
 import { AuthsService } from './auths.service';
 import { PrismaService } from '../shared/prisma.service';
@@ -17,11 +18,21 @@ describe('AuthsService', () => {
     user: {
       create: jest.fn(),
       findUnique: jest.fn(),
+      update: jest.fn(),
     },
   } as unknown as PrismaService;
 
   const jwtServiceMock = {
     signAsync: jest.fn(),
+    verifyAsync: jest.fn(),
+  };
+
+  const configServiceMock = {
+    get: jest.fn((key: string, defaultValue?: number) => {
+      if (key === 'jwt.expiresInSeconds') return 900;
+      if (key === 'jwt.refreshExpiresInSeconds') return 604800;
+      return defaultValue;
+    }),
   };
 
   const i18nServiceMock = {
@@ -43,6 +54,10 @@ describe('AuthsService', () => {
           useValue: jwtServiceMock,
         },
         {
+          provide: ConfigService,
+          useValue: configServiceMock,
+        },
+        {
           provide: I18nService,
           useValue: i18nServiceMock,
         },
@@ -62,7 +77,7 @@ describe('AuthsService', () => {
     const registerDto = {
       name: 'John Doe',
       email: 'john@example.com',
-      password: 'password123',
+      password: 'Password1',
     };
 
     const mockUser = {
@@ -70,6 +85,7 @@ describe('AuthsService', () => {
       name: 'John Doe',
       email: 'john@example.com',
       password: 'hashedPassword',
+      refreshToken: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -78,11 +94,12 @@ describe('AuthsService', () => {
       const hashedPassword = 'hashedPassword';
       (bcrypt.hash as jest.Mock).mockResolvedValue(hashedPassword);
       (prismaService.user.create as jest.Mock).mockResolvedValue(mockUser);
+      (prismaService.user.update as jest.Mock).mockResolvedValue(mockUser);
       jwtServiceMock.signAsync.mockResolvedValue('mock.token');
 
       await service.register(registerDto);
 
-      expect(bcrypt.hash).toHaveBeenCalledWith('password123', 10);
+      expect(bcrypt.hash).toHaveBeenCalledWith('Password1', 10);
       expect(prismaService.user.create).toHaveBeenCalledWith({
         data: {
           name: 'John Doe',
@@ -92,19 +109,28 @@ describe('AuthsService', () => {
       });
     });
 
-    it('should create user and return JWT token', async () => {
-      const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mockToken';
+    it('should create user and return access and refresh tokens', async () => {
+      const mockAccessToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.accessToken';
+      const mockRefreshToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refreshToken';
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashedPassword');
       (prismaService.user.create as jest.Mock).mockResolvedValue(mockUser);
-      jwtServiceMock.signAsync.mockResolvedValue(mockToken);
+      (prismaService.user.update as jest.Mock).mockResolvedValue(mockUser);
+      jwtServiceMock.signAsync
+        .mockResolvedValueOnce(mockAccessToken)
+        .mockResolvedValueOnce(mockRefreshToken);
 
       const result = await service.register(registerDto);
 
-      expect(result).toEqual({ access_token: mockToken });
-      expect(jwtService.signAsync).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        email: mockUser.email,
+      expect(result).toEqual({
+        access_token: mockAccessToken,
+        refresh_token: mockRefreshToken,
       });
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { userId: mockUser.id, email: mockUser.email },
+        { expiresIn: 900 },
+      );
     });
 
     it('should throw ConflictException when email already exists', async () => {
@@ -122,53 +148,69 @@ describe('AuthsService', () => {
       );
     });
 
-    it('should return only access_token without user data', async () => {
+    it('should return access_token and refresh_token without user data', async () => {
       const mockToken = 'token.jwt.value';
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashedPassword');
       (prismaService.user.create as jest.Mock).mockResolvedValue(mockUser);
+      (prismaService.user.update as jest.Mock).mockResolvedValue(mockUser);
       jwtServiceMock.signAsync.mockResolvedValue(mockToken);
 
       const result = await service.register(registerDto);
 
-      expect(result).toEqual({ access_token: mockToken });
+      expect(result).toEqual({
+        access_token: mockToken,
+        refresh_token: mockToken,
+      });
       expect(result).not.toHaveProperty('user');
-      expect(Object.keys(result)).toHaveLength(1);
+      expect(Object.keys(result)).toHaveLength(2);
     });
   });
 
   describe('login', () => {
-    const loginDto = { email: 'john@example.com', password: 'password123' };
+    const loginDto = { email: 'john@example.com', password: 'Password1' };
     const mockUser = {
       id: '123e4567-e89b-12d3-a456-426614174000',
       name: 'John Doe',
       email: 'john@example.com',
       password: 'hashedPassword',
+      refreshToken: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
 
-    it('should return access_token on valid credentials', async () => {
+    it('should return access_token and refresh_token on valid credentials', async () => {
       (prismaService.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-      jwtServiceMock.signAsync.mockResolvedValue('token');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedRefreshToken');
+      (prismaService.user.update as jest.Mock).mockResolvedValue(mockUser);
+      jwtServiceMock.signAsync
+        .mockResolvedValueOnce('access.token')
+        .mockResolvedValueOnce('refresh.token');
 
       const result = await service.login(loginDto);
 
-      expect(result).toEqual({ access_token: 'token' });
+      expect(result).toEqual({
+        access_token: 'access.token',
+        refresh_token: 'refresh.token',
+      });
     });
 
     it('should throw UnauthorizedException on invalid password', async () => {
       (prismaService.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-      await expect(service.login(loginDto)).rejects.toThrow('auth.errors.invalidCredentials');
+      await expect(service.login(loginDto)).rejects.toThrow(
+        'auth.errors.invalidCredentials',
+      );
     });
 
     it('should call bcrypt.compare even when user is not found (timing-safe)', async () => {
       (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-      await expect(service.login(loginDto)).rejects.toThrow('auth.errors.invalidCredentials');
+      await expect(service.login(loginDto)).rejects.toThrow(
+        'auth.errors.invalidCredentials',
+      );
 
       expect(bcrypt.compare).toHaveBeenCalledTimes(1);
       const [, hashArg] = (bcrypt.compare as jest.Mock).mock.calls[0];
@@ -176,48 +218,157 @@ describe('AuthsService', () => {
     });
   });
 
+  describe('refresh', () => {
+    const mockUser = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      email: 'john@example.com',
+      refreshToken: 'storedHashedRefreshToken',
+    };
+
+    it('should return new tokens when refresh token is valid', async () => {
+      jwtServiceMock.verifyAsync.mockResolvedValue({
+        userId: mockUser.id,
+        email: mockUser.email,
+      });
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('newHashedRefreshToken');
+      (prismaService.user.update as jest.Mock).mockResolvedValue(mockUser);
+      jwtServiceMock.signAsync
+        .mockResolvedValueOnce('new.access.token')
+        .mockResolvedValueOnce('new.refresh.token');
+
+      const result = await service.refresh('old.refresh.token');
+
+      expect(result).toEqual({
+        access_token: 'new.access.token',
+        refresh_token: 'new.refresh.token',
+      });
+    });
+
+    it('should throw UnauthorizedException when JWT verification fails', async () => {
+      jwtServiceMock.verifyAsync.mockRejectedValue(new Error('jwt expired'));
+
+      await expect(service.refresh('expired.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.refresh('expired.token')).rejects.toThrow(
+        'auth.errors.invalidRefreshToken',
+      );
+    });
+
+    it('should throw UnauthorizedException when user has no stored refresh token', async () => {
+      jwtServiceMock.verifyAsync.mockResolvedValue({
+        userId: mockUser.id,
+        email: mockUser.email,
+      });
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
+        ...mockUser,
+        refreshToken: null,
+      });
+
+      await expect(service.refresh('some.refresh.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.refresh('some.refresh.token')).rejects.toThrow(
+        'auth.errors.invalidRefreshToken',
+      );
+    });
+
+    it('should throw UnauthorizedException when token hash does not match', async () => {
+      jwtServiceMock.verifyAsync.mockResolvedValue({
+        userId: mockUser.id,
+        email: mockUser.email,
+      });
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(service.refresh('tampered.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.refresh('tampered.token')).rejects.toThrow(
+        'auth.errors.invalidRefreshToken',
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear the stored refresh token', async () => {
+      const userId = '123e4567-e89b-12d3-a456-426614174000';
+      (prismaService.user.update as jest.Mock).mockResolvedValue({});
+
+      await service.logout(userId);
+
+      expect(prismaService.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { refreshToken: null },
+      });
+    });
+  });
+
   describe('generateToken', () => {
-    it('should generate a valid JWT token with correct payload', async () => {
+    it('should generate access and refresh tokens with correct payloads', async () => {
       const userId = '123e4567-e89b-12d3-a456-426614174000';
       const email = 'test@example.com';
-      const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mockToken';
+      const mockAccessToken = 'access.mock.token';
+      const mockRefreshToken = 'refresh.mock.token';
 
-      jwtServiceMock.signAsync.mockResolvedValue(mockToken);
+      jwtServiceMock.signAsync
+        .mockResolvedValueOnce(mockAccessToken)
+        .mockResolvedValueOnce(mockRefreshToken);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedRefreshToken');
+      (prismaService.user.update as jest.Mock).mockResolvedValue({});
 
       const result = await service.generateToken(userId, email);
 
-      expect(result).toEqual({ access_token: mockToken });
-      expect(jwtService.signAsync).toHaveBeenCalledWith({
-        userId,
-        email,
+      expect(result).toEqual({
+        access_token: mockAccessToken,
+        refresh_token: mockRefreshToken,
       });
-      expect(jwtService.signAsync).toHaveBeenCalledTimes(1);
+      expect(jwtService.signAsync).toHaveBeenCalledTimes(2);
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { userId, email },
+        { expiresIn: 900 },
+      );
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { userId, email },
+        { expiresIn: 604800 },
+      );
     });
 
-    it('should return token in OAuth2 format', async () => {
-      const userId = '123e4567-e89b-12d3-a456-426614174000';
-      const email = 'user@example.com';
-      const mockToken = 'mock.jwt.token';
+    it('should store a bcrypt hash of the refresh token in the DB', async () => {
+      const userId = '456e4567-e89b-12d3-a456-426614174001';
+      const email = 'another@example.com';
+      const mockRefreshToken = 'refresh.token.value';
 
-      jwtServiceMock.signAsync.mockResolvedValue(mockToken);
+      jwtServiceMock.signAsync
+        .mockResolvedValueOnce('access.token')
+        .mockResolvedValueOnce(mockRefreshToken);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedValue');
+      (prismaService.user.update as jest.Mock).mockResolvedValue({});
 
-      const result = await service.generateToken(userId, email);
+      await service.generateToken(userId, email);
 
-      expect(result).toHaveProperty('access_token');
-      expect(typeof result.access_token).toBe('string');
+      expect(bcrypt.hash).toHaveBeenCalledWith(mockRefreshToken, 10);
+      expect(prismaService.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { refreshToken: 'hashedValue' },
+      });
     });
 
-    it('should include minimal payload with userId and email only', async () => {
+    it('should use payload with userId and email only', async () => {
       const userId = '456e4567-e89b-12d3-a456-426614174001';
       const email = 'another@example.com';
 
       jwtServiceMock.signAsync.mockResolvedValue('token');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedToken');
+      (prismaService.user.update as jest.Mock).mockResolvedValue({});
 
       await service.generateToken(userId, email);
 
-      const calledPayload = jwtServiceMock.signAsync.mock.calls[0][0];
-      expect(Object.keys(calledPayload)).toHaveLength(2);
-      expect(calledPayload).toEqual({ userId, email });
+      const firstCallPayload = jwtServiceMock.signAsync.mock.calls[0][0];
+      expect(Object.keys(firstCallPayload)).toHaveLength(2);
+      expect(firstCallPayload).toEqual({ userId, email });
     });
   });
 });

--- a/apps/api/src/modules/auths/auths.service.ts
+++ b/apps/api/src/modules/auths/auths.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { Prisma } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
 import { PrismaService } from '../shared/prisma.service';
@@ -16,6 +17,7 @@ export class AuthsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
     private readonly i18n: I18nService,
   ) {}
 
@@ -23,7 +25,9 @@ export class AuthsService {
     return I18nContext.current()?.lang ?? 'en';
   }
 
-  async register(registerDto: RegisterDto): Promise<{ access_token: string }> {
+  async register(
+    registerDto: RegisterDto,
+  ): Promise<{ access_token: string; refresh_token: string }> {
     const { name, email, password } = registerDto;
 
     // Hash password with bcrypt (10 salt rounds)
@@ -39,7 +43,7 @@ export class AuthsService {
         },
       });
 
-      // Generate and return JWT token
+      // Generate and return JWT tokens
       return this.generateToken(user.id, user.email);
     } catch (error) {
       // Handle Prisma unique constraint violation (P2002)
@@ -58,7 +62,9 @@ export class AuthsService {
     }
   }
 
-  async login(loginDto: LoginDto): Promise<{ access_token: string }> {
+  async login(
+    loginDto: LoginDto,
+  ): Promise<{ access_token: string; refresh_token: string }> {
     const { email, password } = loginDto;
 
     const user = await this.prisma.user.findUnique({
@@ -80,13 +86,77 @@ export class AuthsService {
     return this.generateToken(user.id, user.email);
   }
 
+  async refresh(
+    refreshToken: string,
+  ): Promise<{ access_token: string; refresh_token: string }> {
+    let payload: { userId: string; email: string };
+
+    try {
+      payload = await this.jwtService.verifyAsync<{
+        userId: string;
+        email: string;
+      }>(refreshToken);
+    } catch {
+      throw new UnauthorizedException(
+        this.i18n.t('auth.errors.invalidRefreshToken', { lang: this.lang }),
+      );
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: payload.userId },
+    });
+
+    if (!user?.refreshToken) {
+      throw new UnauthorizedException(
+        this.i18n.t('auth.errors.invalidRefreshToken', { lang: this.lang }),
+      );
+    }
+
+    const isValid = await bcrypt.compare(refreshToken, user.refreshToken);
+    if (!isValid) {
+      throw new UnauthorizedException(
+        this.i18n.t('auth.errors.invalidRefreshToken', { lang: this.lang }),
+      );
+    }
+
+    return this.generateToken(user.id, user.email);
+  }
+
+  async logout(userId: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { refreshToken: null },
+    });
+  }
+
   async generateToken(
     userId: string,
     email: string,
-  ): Promise<{ access_token: string }> {
+  ): Promise<{ access_token: string; refresh_token: string }> {
     const payload = { userId, email };
-    const access_token = await this.jwtService.signAsync(payload);
 
-    return { access_token };
+    const accessExpiresIn = this.configService.get<number>(
+      'jwt.expiresInSeconds',
+      900,
+    );
+    const refreshExpiresIn = this.configService.get<number>(
+      'jwt.refreshExpiresInSeconds',
+      604800,
+    );
+
+    const access_token = await this.jwtService.signAsync(payload, {
+      expiresIn: accessExpiresIn,
+    });
+    const refresh_token = await this.jwtService.signAsync(payload, {
+      expiresIn: refreshExpiresIn,
+    });
+
+    const hashedRefreshToken = await bcrypt.hash(refresh_token, 10);
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { refreshToken: hashedRefreshToken },
+    });
+
+    return { access_token, refresh_token };
   }
 }

--- a/apps/api/src/modules/auths/dto/auth-response.dto.ts
+++ b/apps/api/src/modules/auths/dto/auth-response.dto.ts
@@ -2,9 +2,16 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AuthResponseDto {
   @ApiProperty({
-    description: 'JWT access token for authentication',
+    description: 'Short-lived JWT access token (15 minutes)',
     example:
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
   })
   access_token: string;
+
+  @ApiProperty({
+    description: 'Long-lived refresh token (7 days), used to obtain new access tokens',
+    example:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refreshTokenPayload.signature',
+  })
+  refresh_token: string;
 }

--- a/apps/api/src/modules/auths/dto/login.dto.ts
+++ b/apps/api/src/modules/auths/dto/login.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({
@@ -18,5 +24,6 @@ export class LoginDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(6)
+  @MaxLength(128)
   password: string;
 }

--- a/apps/api/src/modules/auths/dto/refresh.dto.ts
+++ b/apps/api/src/modules/auths/dto/refresh.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RefreshDto {
+  @ApiProperty({ description: 'The refresh token issued at login' })
+  @IsString()
+  @IsNotEmpty()
+  refresh_token: string;
+}

--- a/apps/api/src/modules/auths/dto/register.dto.ts
+++ b/apps/api/src/modules/auths/dto/register.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsEmail, MinLength } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsEmail,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { i18nValidationMessage } from 'nestjs-i18n';
 
 export class RegisterDto {
   @ApiProperty({
@@ -8,6 +16,7 @@ export class RegisterDto {
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(100)
   name: string;
 
   @ApiProperty({
@@ -19,12 +28,17 @@ export class RegisterDto {
   email: string;
 
   @ApiProperty({
-    description: 'User password (minimum 6 characters)',
-    example: 'password123',
+    description:
+      'User password (minimum 6 characters, must contain uppercase, lowercase, and number)',
+    example: 'Password1',
     minLength: 6,
   })
   @IsString()
   @IsNotEmpty()
   @MinLength(6)
+  @MaxLength(128)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
+    message: i18nValidationMessage('validation.passwordComplexity'),
+  })
   password: string;
 }

--- a/apps/api/src/modules/categories/dto/create-category.dto.ts
+++ b/apps/api/src/modules/categories/dto/create-category.dto.ts
@@ -1,14 +1,16 @@
-import { IsString } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCategoryDto {
   @ApiProperty({ description: 'The name of the category' })
   @IsString()
+  @MaxLength(100)
   name: string;
 
   @ApiProperty({
     description: 'The type of the category (e.g., expense, income)',
   })
   @IsString()
+  @MaxLength(20)
   type: string;
 }

--- a/apps/api/src/modules/categories/dto/update-category.dto.ts
+++ b/apps/api/src/modules/categories/dto/update-category.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateCategoryDto {
@@ -7,6 +7,7 @@ export class UpdateCategoryDto {
   @ApiProperty({ description: 'The name of the category', required: false })
   @IsOptional()
   @IsString()
+  @MaxLength(100)
   name?: string;
 
   @ApiProperty({
@@ -15,5 +16,6 @@ export class UpdateCategoryDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(20)
   type?: string;
 }

--- a/apps/api/src/modules/config/configuration.ts
+++ b/apps/api/src/modules/config/configuration.ts
@@ -18,7 +18,8 @@ export const databaseConfig = registerAs('database', () => ({
 
 export const jwtConfig = registerAs('jwt', () => ({
   secret: process.env.JWT_SECRET,
-  expiresInSeconds: parseNumber(process.env.JWT_EXPIRATION, 3600),
+  expiresInSeconds: parseNumber(process.env.JWT_EXPIRATION, 900),
+  refreshExpiresInSeconds: parseNumber(process.env.JWT_REFRESH_EXPIRATION, 604800),
 }));
 
 export const configurations = [appConfig, databaseConfig, jwtConfig];

--- a/apps/api/src/modules/config/env.validation.ts
+++ b/apps/api/src/modules/config/env.validation.ts
@@ -9,6 +9,7 @@ export const envValidationSchema = Joi.object({
     .uri({ scheme: ['postgresql', 'postgres'] })
     .required(),
   JWT_SECRET: Joi.string().min(32).required(),
-  JWT_EXPIRATION: Joi.number().integer().positive().default(3600),
+  JWT_EXPIRATION: Joi.number().integer().positive().default(900),
+  JWT_REFRESH_EXPIRATION: Joi.number().integer().positive().default(604800),
   CORS_ORIGINS: Joi.string().optional(),
 });

--- a/apps/api/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/apps/api/src/modules/transactions/dto/create-transaction.dto.ts
@@ -5,6 +5,7 @@ import {
   IsPositive,
   IsString,
   IsUUID,
+  MaxLength,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -23,6 +24,7 @@ export class CreateTransactionDto {
     example: 'EXPENSE',
   })
   @IsString()
+  @MaxLength(20)
   type: string;
 
   @ApiProperty({
@@ -46,5 +48,6 @@ export class CreateTransactionDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(500)
   description?: string;
 }

--- a/apps/api/src/modules/transactions/dto/update-transaction.dto.ts
+++ b/apps/api/src/modules/transactions/dto/update-transaction.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -24,6 +25,7 @@ export class UpdateTransactionDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(20)
   type?: string;
 
   @ApiProperty({
@@ -51,5 +53,6 @@ export class UpdateTransactionDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(500)
   description?: string;
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -63,7 +63,8 @@
     "creatingAccount": "Creating account...",
     "alreadyHaveAccount": "Already have an account?",
     "loginSuccess": "Login successful!",
-    "registerSuccess": "Account created successfully!"
+    "registerSuccess": "Account created successfully!",
+    "passwordComplexity": "Password must contain at least one uppercase letter, one lowercase letter, and one number"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -63,7 +63,8 @@
     "creatingAccount": "Criando conta...",
     "alreadyHaveAccount": "Já tem uma conta?",
     "loginSuccess": "Login realizado com sucesso!",
-    "registerSuccess": "Conta criada com sucesso!"
+    "registerSuccess": "Conta criada com sucesso!",
+    "passwordComplexity": "A senha deve conter pelo menos uma letra maiúscula, uma letra minúscula e um número"
   },
   "dashboard": {
     "title": "Painel",

--- a/prisma/migrations/20260309225937_add_refresh_token_to_user/migration.sql
+++ b/prisma/migrations/20260309225937_add_refresh_token_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "refreshToken" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   name         String
   email        String        @unique
   password     String
+  refreshToken String?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   categories   Category[]


### PR DESCRIPTION
…kens

- Add @MaxLength to all DTO string fields to prevent oversized payload attacks
- Add @Matches password complexity rule on register (uppercase, lowercase, digit)
- Implement short-lived access tokens (15m) + long-lived refresh tokens (7d)
- Add POST /auths/refresh and POST /auths/logout endpoints
- Store bcrypt hash of refresh token in DB for stateful revocation
- Add refreshToken field to User model with migration
- Add invalidRefreshToken i18n keys (en + pt-BR)
- Add passwordComplexity i18n keys (backend + frontend, en + pt-BR)
- Update JWT_EXPIRATION default from 3600s to 900s
- 161 tests passing