### PR TITLE
docs: update docs for security hardening changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,10 @@ DATABASE_URL="postgresql://user:password@localhost:5432/my_pocket_db?schema=publ
 # JWT Configuration
 # Use a strong, unique secret with at least 32 characters
 JWT_SECRET=change-me-to-a-long-random-string-with-at-least-32-characters
-# Expiration in seconds (3600 = 1 hour)
-JWT_EXPIRATION=3600
+# Expiration in seconds (900 = 15 minutes)
+JWT_EXPIRATION=900
+# Refresh token expiration in seconds (604800 = 7 days)
+JWT_REFRESH_EXPIRATION=604800
+
+# CORS
+CORS_ORIGINS=http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm run test:cov                      # With coverage
 # API unit tests (Jest, NODE_ENV=test)
 cd apps/api && npm run test           # All unit tests
 cd apps/api && npm run test:watch     # Watch mode
-cd apps/api && npm test -- --testPathPattern=auths  # Single module
+cd apps/api && npm test -- --testPathPatterns=auths  # Single module
 
 # API e2e tests
 cd apps/api && npm run test:e2e       # Requires test DB running on port 5433
@@ -61,7 +61,7 @@ This is a **Turborepo + npm workspaces** monorepo:
 ### Backend (`apps/api`)
 
 **NestJS modular architecture** under `src/modules/`:
-- `auths` — registration, login, JWT strategy (`jwt.strategy.ts`), guard (`jwt-auth.guard.ts`)
+- `auths` — registration, login, logout, refresh token rotation; JWT strategy (`jwt.strategy.ts`), guard (`jwt-auth.guard.ts`)
 - `categories`, `transactions`, `budgets`, `dashboard` — domain modules, each with controller/service/dto
 - `health` — single `GET /health` endpoint for service availability checks
 - `shared` — exports `PrismaService` (extends `PrismaClient`) and `formatDecimal` utility; imported as `SharedModule` globally
@@ -71,6 +71,8 @@ This is a **Turborepo + npm workspaces** monorepo:
 **Request flow:** Controller → `JwtAuthGuard` → Service → `PrismaService`
 
 **JWT payload:** `{ userId, email }` — controllers extract `userId` from the request user object to enforce per-user data isolation in every query.
+
+**Auth response:** `{ access_token: string; refresh_token: string }`. Access token expires in 15 min; refresh token expires in 7 days and is stored as a bcrypt hash in `User.refreshToken`. Use `POST /auths/refresh` with the refresh token to rotate both tokens. Use `POST /auths/logout` (JWT-guarded) to revoke.
 
 **Env file resolution** (in `app.module.ts`):
 - `NODE_ENV=test` → `.env.test`
@@ -114,7 +116,7 @@ Contains TypeScript interfaces (`ApiResponse`, `PaginatedResponse`, base entity 
 
 ### Database Schema
 Four models in `prisma/schema.prisma`:
-- `User` — owns all other entities
+- `User` — owns all other entities; `refreshToken String?` stores the bcrypt hash of the active refresh token (null after logout)
 - `Category` — `(name, type, userId)` unique; type is `INCOME | EXPENSE`
 - `Transaction` — linked to a category; amount stored as `Decimal(10,2)`
 - `Budget` — `(categoryId, month, year, userId)` unique; tracks budget per category per month

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ DATABASE_URL="postgresql://user:password@localhost:5432/my_pocket_db?schema=publ
 
 # JWT Authentication (secret must be >= 32 chars)
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
-JWT_EXPIRATION=3600
+JWT_EXPIRATION=900          # Access token TTL in seconds (15 minutes)
+JWT_REFRESH_EXPIRATION=604800  # Refresh token TTL in seconds (7 days)
+
+# CORS
+CORS_ORIGINS=http://localhost:3000
 ```
 
 For the frontend, create `apps/web/.env.local`:
@@ -256,6 +260,8 @@ Once the API is running, visit:
 | ------------------------------- | ------ | ---------------------------------- |
 | `/auths/register`               | POST   | Register a new user                |
 | `/auths/login`                  | POST   | Login and get JWT token            |
+| `/auths/refresh`                | POST   | Exchange refresh token for new access + refresh tokens |
+| `/auths/logout`                 | POST   | Invalidate current refresh token (requires Bearer auth) |
 | `/categories`                   | GET    | List all categories                |
 | `/categories/:id`               | GET    | Get category by ID                 |
 | `/categories`                   | POST   | Create a new category              |
@@ -294,6 +300,11 @@ Once the API is running, visit:
 - ✅ Global exception handling
 - ✅ Interactive API documentation (Swagger/OpenAPI at `/docs`)
 - ✅ Internationalized error messages (EN / PT-BR via `Accept-Language` header)
+- ✅ Rate limiting on auth endpoints (5 req/min) and refresh (10 req/min)
+- ✅ Helmet security headers
+- ✅ CORS restricted to configured origins
+- ✅ Password complexity enforcement on registration (uppercase + lowercase + digit)
+- ✅ Short-lived access tokens (15 min) + revocable refresh tokens (7 days)
 
 ### Frontend
 - ✅ Dashboard as post-login landing page with charts and monthly summary


### PR DESCRIPTION
Document refresh token pair endpoints, JWT_EXPIRATION change (3600→900), new env vars (JWT_REFRESH_EXPIRATION, CORS_ORIGINS), rate limiting, Helmet, CORS, and password complexity features. Fix deprecated --testPathPattern flag.