### PR TITLE
fix(security): harden web frontend with token rotation, CSP headers, …

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,16 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
+const CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'", // 'unsafe-inline' required by Next.js hydration
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  `connect-src 'self' ${API_URL}`,
+  "frame-ancestors 'none'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -21,18 +31,10 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self'",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data:",
-              "font-src 'self'",
-              `connect-src 'self' ${API_URL}`,
-              "frame-ancestors 'none'",
-            ].join('; '),
-          },
+          // CSP only in production — Turbopack dev server requires inline scripts for HMR
+          ...(process.env.NODE_ENV === 'production'
+            ? [{ key: 'Content-Security-Policy', value: CSP_DIRECTIVES }]
+            : []),
         ],
       },
     ];

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,10 +2,41 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   transpilePackages: ['@my-pocket/shared'],
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data:",
+              "font-src 'self'",
+              `connect-src 'self' ${API_URL}`,
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/src/app/budgets/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/budgets/[id]/edit/page.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
-import { mockBudgets, mockToken } from '@/test/mocks/handlers';
-import { renderWithProviders } from '@/test/test-utils';
+import { mockBudgets } from '@/test/mocks/handlers';
+import { renderWithAuthenticatedProviders } from '@/test/test-utils';
 import EditBudgetPage from './page';
 
 const API_URL = 'http://localhost:3001';
@@ -33,17 +33,16 @@ describe('EditBudgetPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('shows loading state initially', async () => {
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('renders Edit Budget page with form pre-filled', async () => {
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Edit Budget')).toBeInTheDocument();
@@ -60,7 +59,7 @@ describe('EditBudgetPage', () => {
   });
 
   it('renders within AuthLayout', async () => {
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Edit Budget')).toBeInTheDocument();
@@ -83,7 +82,7 @@ describe('EditBudgetPage', () => {
       }),
     );
 
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Budget not found');
@@ -102,7 +101,7 @@ describe('EditBudgetPage', () => {
       }),
     );
 
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -121,7 +120,7 @@ describe('EditBudgetPage', () => {
       }),
     );
 
-    renderWithProviders(<EditBudgetPage />);
+    renderWithAuthenticatedProviders(<EditBudgetPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Server error');

--- a/apps/web/src/app/budgets/new/page.test.tsx
+++ b/apps/web/src/app/budgets/new/page.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
-import { mockToken } from '@/test/mocks/handlers';
-import { renderWithProviders } from '@/test/test-utils';
+import { renderWithAuthenticatedProviders } from '@/test/test-utils';
 import NewBudgetPage from './page';
 
 // Mock next/navigation
@@ -26,11 +25,10 @@ describe('NewBudgetPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders Create Budget page with form', async () => {
-    renderWithProviders(<NewBudgetPage />);
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Create Budget')).toBeInTheDocument();
@@ -46,7 +44,7 @@ describe('NewBudgetPage', () => {
   });
 
   it('renders within AuthLayout', async () => {
-    renderWithProviders(<NewBudgetPage />);
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Create Budget')).toBeInTheDocument();

--- a/apps/web/src/app/budgets/page.test.tsx
+++ b/apps/web/src/app/budgets/page.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
-import { mockBudgets, mockToken } from '@/test/mocks/handlers';
+import { mockBudgets } from '@/test/mocks/handlers';
 import {
-  renderWithProviders,
+  renderWithAuthenticatedProviders,
   setupUser,
   selectOption,
 } from '@/test/test-utils';
@@ -31,17 +31,16 @@ describe('BudgetsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders loading skeleton initially', () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
     // The skeleton should be visible while loading
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
   it('renders budget list from API', async () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       // Budget amounts should be displayed
@@ -54,7 +53,7 @@ describe('BudgetsPage', () => {
   });
 
   it('displays category names for budgets', async () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       // Category names should be resolved from categoryId
@@ -71,7 +70,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(
@@ -84,7 +83,7 @@ describe('BudgetsPage', () => {
 
   it('shows "no matches" message when filters yield no results', async () => {
     const user = setupUser();
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -100,7 +99,7 @@ describe('BudgetsPage', () => {
 
   it('filters budgets by type', async () => {
     const user = setupUser();
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -135,7 +134,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -171,7 +170,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -187,7 +186,7 @@ describe('BudgetsPage', () => {
   });
 
   it('has New Budget button that links to create page', async () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -198,7 +197,7 @@ describe('BudgetsPage', () => {
   });
 
   it('has Edit buttons that link to edit pages', async () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -212,7 +211,7 @@ describe('BudgetsPage', () => {
 
   it('opens delete confirmation dialog when Delete is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -230,7 +229,7 @@ describe('BudgetsPage', () => {
 
   it('closes delete dialog when Cancel is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -253,7 +252,7 @@ describe('BudgetsPage', () => {
   it('deletes budget when confirmed and removes from list', async () => {
     const user = setupUser();
     const { toast } = await import('sonner');
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -288,7 +287,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -306,7 +305,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Server error');
@@ -321,7 +320,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to load budgets');
@@ -344,7 +343,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -393,7 +392,7 @@ describe('BudgetsPage', () => {
       }),
     );
 
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
@@ -413,7 +412,7 @@ describe('BudgetsPage', () => {
   });
 
   it('displays period as Month/Year format', async () => {
-    renderWithProviders(<BudgetsPage />);
+    renderWithAuthenticatedProviders(<BudgetsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();

--- a/apps/web/src/app/categories/page.test.tsx
+++ b/apps/web/src/app/categories/page.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
-import { mockCategories, mockToken } from '@/test/mocks/handlers';
+import { mockCategories } from '@/test/mocks/handlers';
 import {
-  renderWithProviders,
+  renderWithAuthenticatedProviders,
   setupUser,
   selectOption,
 } from '@/test/test-utils';
@@ -34,17 +34,16 @@ describe('CategoriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders loading skeleton initially', () => {
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
     // The skeleton should be visible while loading
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
   it('renders category list from API', async () => {
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -62,7 +61,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(
@@ -75,7 +74,7 @@ describe('CategoriesPage', () => {
 
   it('shows "no matches" message when search yields no results', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -91,7 +90,7 @@ describe('CategoriesPage', () => {
 
   it('filters categories by search query', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -106,7 +105,7 @@ describe('CategoriesPage', () => {
 
   it('filters categories by type with dropdown', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -121,7 +120,7 @@ describe('CategoriesPage', () => {
 
   it('filters to show only expense categories', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Groceries')).toBeInTheDocument();
@@ -135,7 +134,7 @@ describe('CategoriesPage', () => {
   });
 
   it('has New Category button that links to create page', async () => {
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -146,7 +145,7 @@ describe('CategoriesPage', () => {
   });
 
   it('has Edit buttons that link to edit pages', async () => {
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -160,7 +159,7 @@ describe('CategoriesPage', () => {
 
   it('opens delete confirmation dialog when Delete is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -178,7 +177,7 @@ describe('CategoriesPage', () => {
 
   it('closes delete dialog when Cancel is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -201,7 +200,7 @@ describe('CategoriesPage', () => {
   it('deletes category when confirmed and removes from list', async () => {
     const user = setupUser();
     const { toast } = await import('sonner');
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -238,7 +237,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -256,7 +255,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Server error');
@@ -271,7 +270,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to load categories');
@@ -294,7 +293,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();
@@ -334,7 +333,7 @@ describe('CategoriesPage', () => {
       }),
     );
 
-    renderWithProviders(<CategoriesPage />);
+    renderWithAuthenticatedProviders(<CategoriesPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Salary')).toBeInTheDocument();

--- a/apps/web/src/app/dashboard/page.test.tsx
+++ b/apps/web/src/app/dashboard/page.test.tsx
@@ -9,7 +9,7 @@ import {
   mockBudgetVsActual,
   mockTopExpenses,
 } from '@/test/mocks/handlers';
-import { renderWithProviders, setupUser } from '@/test/test-utils';
+import { renderWithAuthenticatedProviders, setupUser } from '@/test/test-utils';
 import DashboardPage from './page';
 
 const API_URL = 'http://localhost:3001';
@@ -56,16 +56,15 @@ vi.mock('next/navigation', async () => ({
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders loading skeletons initially', () => {
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
   it('renders monthly summary cards with correct values', async () => {
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Total Income')).toBeInTheDocument();
@@ -80,7 +79,7 @@ describe('DashboardPage', () => {
   });
 
   it('renders category breakdown section with category names', async () => {
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Category Breakdown')).toBeInTheDocument();
@@ -92,7 +91,7 @@ describe('DashboardPage', () => {
   });
 
   it('renders budget vs actual section with category names', async () => {
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Budget vs Actual')).toBeInTheDocument();
@@ -105,7 +104,7 @@ describe('DashboardPage', () => {
   });
 
   it('renders top expenses table with expense rows', async () => {
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Groceries')).toBeInTheDocument();
@@ -120,7 +119,7 @@ describe('DashboardPage', () => {
 
   it('clicking previous month decrements the month display', async () => {
     const user = setupUser();
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Total Income')).toBeInTheDocument();
@@ -141,7 +140,7 @@ describe('DashboardPage', () => {
 
   it('clicking next month increments the month display', async () => {
     const user = setupUser();
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Total Income')).toBeInTheDocument();
@@ -172,7 +171,7 @@ describe('DashboardPage', () => {
       ),
     );
 
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('No expenses for this period.')).toBeInTheDocument();
@@ -193,7 +192,7 @@ describe('DashboardPage', () => {
       ),
     );
 
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Balance')).toBeInTheDocument();
@@ -213,7 +212,7 @@ describe('DashboardPage', () => {
       ),
     );
 
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -230,7 +229,7 @@ describe('DashboardPage', () => {
       ),
     );
 
-    renderWithProviders(<DashboardPage />);
+    renderWithAuthenticatedProviders(<DashboardPage />);
 
     await waitFor(() => {
       expect(

--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -28,7 +28,6 @@ vi.mock('sonner', () => ({
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(localStorage.getItem).mockReturnValue(null);
   });
 
   it('renders email and password inputs', () => {
@@ -187,7 +186,7 @@ describe('LoginPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('stores token in localStorage on successful login', async () => {
+  it('stores refresh token in cookie on successful login', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<LoginPage />);
@@ -197,7 +196,7 @@ describe('LoginPage', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
-      expect(localStorage.setItem).toHaveBeenCalled();
+      expect(document.cookie).toContain('refresh_token=');
     });
   });
 

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -28,7 +28,6 @@ vi.mock('sonner', () => ({
 describe('RegisterPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(localStorage.getItem).mockReturnValue(null);
   });
 
   it('renders name, email, and password inputs', () => {
@@ -206,7 +205,7 @@ describe('RegisterPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('stores token in localStorage on successful registration', async () => {
+  it('stores refresh token in cookie on successful registration', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<RegisterPage />);
@@ -217,7 +216,7 @@ describe('RegisterPage', () => {
     await user.click(screen.getByRole('button', { name: 'Create an account' }));
 
     await waitFor(() => {
-      expect(localStorage.setItem).toHaveBeenCalled();
+      expect(document.cookie).toContain('refresh_token=');
     });
   });
 

--- a/apps/web/src/app/transactions/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/transactions/[id]/edit/page.test.tsx
@@ -2,8 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
-import { mockToken } from '@/test/mocks/handlers';
-import { renderWithProviders } from '@/test/test-utils';
+import { renderWithAuthenticatedProviders } from '@/test/test-utils';
 import EditTransactionPage from './page';
 
 const API_URL = 'http://localhost:3001';
@@ -33,17 +32,16 @@ describe('EditTransactionPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('shows loading state initially', async () => {
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('renders Edit Transaction page with form pre-filled', async () => {
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Edit Transaction')).toBeInTheDocument();
@@ -60,7 +58,7 @@ describe('EditTransactionPage', () => {
   });
 
   it('renders within AuthLayout', async () => {
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Edit Transaction')).toBeInTheDocument();
@@ -83,7 +81,7 @@ describe('EditTransactionPage', () => {
       }),
     );
 
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to load transaction');
@@ -102,7 +100,7 @@ describe('EditTransactionPage', () => {
       }),
     );
 
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -121,7 +119,7 @@ describe('EditTransactionPage', () => {
       }),
     );
 
-    renderWithProviders(<EditTransactionPage />);
+    renderWithAuthenticatedProviders(<EditTransactionPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Server error');

--- a/apps/web/src/app/transactions/new/page.test.tsx
+++ b/apps/web/src/app/transactions/new/page.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
-import { mockToken } from '@/test/mocks/handlers';
-import { renderWithProviders } from '@/test/test-utils';
+import { renderWithAuthenticatedProviders } from '@/test/test-utils';
 import NewTransactionPage from './page';
 
 // Mock next/navigation
@@ -26,11 +25,10 @@ describe('NewTransactionPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders Create Transaction page with form', async () => {
-    renderWithProviders(<NewTransactionPage />);
+    renderWithAuthenticatedProviders(<NewTransactionPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Create Transaction')).toBeInTheDocument();
@@ -45,7 +43,7 @@ describe('NewTransactionPage', () => {
   });
 
   it('renders within AuthLayout', async () => {
-    renderWithProviders(<NewTransactionPage />);
+    renderWithAuthenticatedProviders(<NewTransactionPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Create Transaction')).toBeInTheDocument();

--- a/apps/web/src/app/transactions/page.test.tsx
+++ b/apps/web/src/app/transactions/page.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
-import { mockTransactions, mockToken } from '@/test/mocks/handlers';
+import { mockTransactions } from '@/test/mocks/handlers';
 import {
-  renderWithProviders,
+  renderWithAuthenticatedProviders,
   setupUser,
   selectOption,
 } from '@/test/test-utils';
@@ -34,17 +34,16 @@ describe('TransactionsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set up authenticated state
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
   });
 
   it('renders loading skeleton initially', () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
     // The skeleton should be visible while loading
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
   it('renders transaction list from API', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       // Transaction amounts should be displayed
@@ -57,7 +56,7 @@ describe('TransactionsPage', () => {
   });
 
   it('displays category names for transactions', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       // Category names should be resolved from categoryId
@@ -68,7 +67,7 @@ describe('TransactionsPage', () => {
   });
 
   it('displays transaction descriptions', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
@@ -84,7 +83,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(
@@ -97,7 +96,7 @@ describe('TransactionsPage', () => {
 
   it('shows "no matches" message when filters yield no results', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -119,7 +118,7 @@ describe('TransactionsPage', () => {
 
   it('filters transactions by type', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -135,7 +134,7 @@ describe('TransactionsPage', () => {
 
   it('filters transactions by category', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -172,7 +171,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -194,7 +193,7 @@ describe('TransactionsPage', () => {
   });
 
   it('has New Transaction button that links to create page', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -205,7 +204,7 @@ describe('TransactionsPage', () => {
   });
 
   it('has Edit buttons that link to edit pages', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -225,7 +224,7 @@ describe('TransactionsPage', () => {
 
   it('opens delete confirmation dialog when Delete is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -243,7 +242,7 @@ describe('TransactionsPage', () => {
 
   it('closes delete dialog when Cancel is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -266,7 +265,7 @@ describe('TransactionsPage', () => {
   it('deletes transaction when confirmed and removes from list', async () => {
     const user = setupUser();
     const { toast } = await import('sonner');
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -303,7 +302,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith('/login');
@@ -321,7 +320,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Server error');
@@ -336,7 +335,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to load transactions');
@@ -359,7 +358,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -412,7 +411,7 @@ describe('TransactionsPage', () => {
       }),
     );
 
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -438,7 +437,7 @@ describe('TransactionsPage', () => {
   });
 
   it('displays date in formatted format', async () => {
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
@@ -451,7 +450,7 @@ describe('TransactionsPage', () => {
 
   it('clears filters when clear button is clicked', async () => {
     const user = setupUser();
-    renderWithProviders(<TransactionsPage />);
+    renderWithAuthenticatedProviders(<TransactionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import {
   Card,
-  CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
@@ -61,15 +60,6 @@ class ErrorBoundaryInner extends Component<
               <CardTitle className="text-2xl font-bold">{title}</CardTitle>
               <CardDescription>{description}</CardDescription>
             </CardHeader>
-            {this.state.error && (
-              <CardContent>
-                <div className="rounded-md bg-muted p-3">
-                  <p className="text-sm text-muted-foreground font-mono break-all">
-                    {this.state.error.message}
-                  </p>
-                </div>
-              </CardContent>
-            )}
             <CardFooter className="flex flex-col space-y-2">
               <Button onClick={this.handleRetry} className="w-full">
                 {tryAgain}

--- a/apps/web/src/contexts/AuthContext.test.tsx
+++ b/apps/web/src/contexts/AuthContext.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AuthProvider, useAuth } from './AuthContext';
-import { mockToken, mockUser } from '@/test/mocks/handlers';
+import { mockToken, mockRefreshToken, mockUser } from '@/test/mocks/handlers';
 
 // Test component that uses the auth context
 function TestComponent() {
@@ -39,10 +39,15 @@ function TestComponent() {
 
 describe('AuthContext', () => {
   beforeEach(() => {
-    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    // Ensure no refresh token cookie is set before each test
+    document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
   });
 
-  it('should provide initial unauthenticated state', async () => {
+  afterEach(() => {
+    document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
+  });
+
+  it('should provide initial unauthenticated state when no cookie', async () => {
     render(
       <AuthProvider>
         <TestComponent />
@@ -57,8 +62,8 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('user')).toHaveTextContent('none');
   });
 
-  it('should load user from localStorage on mount', async () => {
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+  it('should restore session from valid refresh token cookie', async () => {
+    document.cookie = `refresh_token=${mockRefreshToken}; path=/`;
 
     render(
       <AuthProvider>
@@ -67,15 +72,15 @@ describe('AuthContext', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('loading')).toHaveTextContent('ready');
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('yes');
     });
 
-    expect(screen.getByTestId('authenticated')).toHaveTextContent('yes');
     expect(screen.getByTestId('user')).toHaveTextContent(mockUser.email);
+    expect(screen.getByTestId('loading')).toHaveTextContent('ready');
   });
 
-  it('should clear invalid token from localStorage', async () => {
-    vi.mocked(localStorage.getItem).mockReturnValue('invalid-token');
+  it('should clear cookie and stay unauthenticated when refresh token is invalid', async () => {
+    document.cookie = 'refresh_token=invalid-token-value; path=/';
 
     render(
       <AuthProvider>
@@ -87,11 +92,11 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('loading')).toHaveTextContent('ready');
     });
 
-    expect(localStorage.removeItem).toHaveBeenCalledWith('token');
     expect(screen.getByTestId('authenticated')).toHaveTextContent('no');
+    expect(document.cookie).not.toContain('invalid-token-value');
   });
 
-  it('should login successfully', async () => {
+  it('should login successfully and set refresh token cookie', async () => {
     const user = userEvent.setup();
 
     render(
@@ -110,11 +115,11 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('authenticated')).toHaveTextContent('yes');
     });
 
-    expect(localStorage.setItem).toHaveBeenCalledWith('token', mockToken);
+    expect(document.cookie).toContain('refresh_token=');
     expect(screen.getByTestId('user')).toHaveTextContent(mockUser.email);
   });
 
-  it('should register successfully', async () => {
+  it('should register successfully and set refresh token cookie', async () => {
     const user = userEvent.setup();
 
     render(
@@ -133,12 +138,12 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('authenticated')).toHaveTextContent('yes');
     });
 
-    expect(localStorage.setItem).toHaveBeenCalledWith('token', mockToken);
+    expect(document.cookie).toContain('refresh_token=');
   });
 
-  it('should logout successfully', async () => {
+  it('should logout successfully and clear cookie', async () => {
     const user = userEvent.setup();
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+    document.cookie = `refresh_token=${mockRefreshToken}; path=/`;
 
     render(
       <AuthProvider>
@@ -156,8 +161,8 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('authenticated')).toHaveTextContent('no');
     });
 
-    expect(localStorage.removeItem).toHaveBeenCalledWith('token');
     expect(screen.getByTestId('user')).toHaveTextContent('none');
+    expect(document.cookie).not.toContain(mockRefreshToken);
   });
 
   it('should throw error when useAuth is used outside provider', () => {

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
   useCallback,
   ReactNode,
 } from 'react';
-import { api, ApiException } from '@/lib/api';
+import { api, ApiException, setAccessToken } from '@/lib/api';
 import { AuthResponse, LoginRequest, RegisterRequest, User } from '@/types';
 
 interface AuthContextType {
@@ -21,7 +21,7 @@ interface AuthContextType {
   logout: () => void;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 function decodeToken(token: string): User | null {
   try {
@@ -37,23 +37,67 @@ function decodeToken(token: string): User | null {
   }
 }
 
+function setRefreshTokenCookie(token: string): void {
+  const maxAge = 60 * 60 * 24 * 7; // 7 days — matches backend refresh token expiry
+  const secure =
+    typeof location !== 'undefined' && location.protocol === 'https:'
+      ? '; Secure'
+      : '';
+  document.cookie = `refresh_token=${token}; path=/; max-age=${maxAge}; SameSite=Strict${secure}`;
+}
+
+function getRefreshTokenCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie
+    .split('; ')
+    .find((r) => r.startsWith('refresh_token='));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}
+
+function clearRefreshTokenCookie(): void {
+  document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  function applySession(accessToken: string): void {
+    const decodedUser = decodeToken(accessToken);
+    setAccessToken(accessToken);
+    setToken(accessToken);
+    setUser(decodedUser);
+  }
+
+  function clearSession(): void {
+    setAccessToken(null);
+    setToken(null);
+    setUser(null);
+  }
+
   useEffect(() => {
-    const storedToken = localStorage.getItem('token');
-    if (storedToken) {
-      const decodedUser = decodeToken(storedToken);
-      if (decodedUser) {
-        setToken(storedToken);
-        setUser(decodedUser);
-      } else {
-        localStorage.removeItem('token');
-      }
+    const refreshToken = getRefreshTokenCookie();
+    if (!refreshToken) {
+      setIsLoading(false);
+      return;
     }
-    setIsLoading(false);
+    api
+      .post<AuthResponse>('/auths/refresh', { refresh_token: refreshToken })
+      .then((response) => {
+        if (response.refresh_token) {
+          setRefreshTokenCookie(response.refresh_token);
+        }
+        applySession(response.access_token);
+      })
+      .catch(() => {
+        clearRefreshTokenCookie();
+        clearSession();
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const login = useCallback(async (data: LoginRequest) => {
@@ -62,7 +106,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!decodedUser) {
       throw new ApiException(401, 'Invalid token received');
     }
-    localStorage.setItem('token', response.access_token);
+    if (response.refresh_token) {
+      setRefreshTokenCookie(response.refresh_token);
+    }
+    setAccessToken(response.access_token);
     setToken(response.access_token);
     setUser(decodedUser);
   }, []);
@@ -73,15 +120,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!decodedUser) {
       throw new ApiException(401, 'Invalid token received');
     }
-    localStorage.setItem('token', response.access_token);
+    if (response.refresh_token) {
+      setRefreshTokenCookie(response.refresh_token);
+    }
+    setAccessToken(response.access_token);
     setToken(response.access_token);
     setUser(decodedUser);
   }, []);
 
   const logout = useCallback(() => {
-    localStorage.removeItem('token');
-    setToken(null);
-    setUser(null);
+    api.post('/auths/logout').catch(() => {}); // best-effort server-side revocation
+    clearRefreshTokenCookie();
+    clearSession();
   }, []);
 
   return (

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { api, apiRequest, ApiException } from './api';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { api, apiRequest, ApiException, setAccessToken } from './api';
 import { mockToken } from '@/test/mocks/handlers';
 
 describe('api', () => {
   beforeEach(() => {
-    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    setAccessToken(null);
   });
 
   describe('apiRequest', () => {
     it('should add Authorization header when token exists', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+      setAccessToken(mockToken);
 
       const result = await api.get('/categories');
 
@@ -18,13 +18,13 @@ describe('api', () => {
     });
 
     it('should not add Authorization header when no token', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       await expect(api.get('/categories')).rejects.toThrow(ApiException);
     });
 
     it('should throw ApiException on 401 error', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       try {
         await api.get('/categories');
@@ -32,7 +32,6 @@ describe('api', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(ApiException);
         expect((error as ApiException).statusCode).toBe(401);
-        expect((error as ApiException).message).toBe('Unauthorized');
       }
     });
 
@@ -59,7 +58,7 @@ describe('api', () => {
     });
 
     it('should handle 204 No Content response', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+      setAccessToken(mockToken);
 
       const result = await api.delete('/categories/cat-1');
 
@@ -69,7 +68,7 @@ describe('api', () => {
 
   describe('api methods', () => {
     beforeEach(() => {
-      vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+      setAccessToken(mockToken);
     });
 
     it('api.get should make GET request', async () => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,9 +12,23 @@ export class ApiException extends Error {
   }
 }
 
+// Module-level access token — set by AuthContext, read by apiRequest
+let _accessToken: string | null = null;
+
+export function setAccessToken(token: string | null): void {
+  _accessToken = token;
+}
+
 function getToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem('token');
+  return _accessToken;
+}
+
+function getRefreshTokenFromCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie
+    .split('; ')
+    .find((r) => r.startsWith('refresh_token='));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
 }
 
 function getLocale(): string {
@@ -25,9 +39,45 @@ function getLocale(): string {
   return match ? match.split('=')[1] : 'en';
 }
 
+// Auth endpoints that should NOT trigger the 401 refresh interceptor
+const SKIP_REFRESH_ENDPOINTS = [
+  '/auths/refresh',
+  '/auths/login',
+  '/auths/register',
+];
+
+async function tryRefreshToken(): Promise<string | null> {
+  const refreshToken = getRefreshTokenFromCookie();
+  if (!refreshToken) return null;
+
+  try {
+    const response = await fetch(`${API_URL}/auths/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+
+    if (!response.ok) {
+      // Revoke the stale refresh token cookie
+      document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
+      return null;
+    }
+
+    const data = await response.json();
+    if (data.refresh_token) {
+      const maxAge = 60 * 60 * 24 * 7;
+      document.cookie = `refresh_token=${data.refresh_token}; path=/; max-age=${maxAge}; SameSite=Strict`;
+    }
+    return data.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function apiRequest<T>(
   endpoint: string,
   options: RequestInit = {},
+  _isRetry = false,
 ): Promise<T> {
   const token = getToken();
   const headers: HeadersInit = {
@@ -44,6 +94,24 @@ export async function apiRequest<T>(
     ...options,
     headers,
   });
+
+  if (
+    response.status === 401 &&
+    !_isRetry &&
+    !SKIP_REFRESH_ENDPOINTS.includes(endpoint)
+  ) {
+    const newToken = await tryRefreshToken();
+    if (newToken) {
+      setAccessToken(newToken);
+      return apiRequest<T>(endpoint, options, true);
+    }
+    // Refresh failed — clear state and redirect to login
+    setAccessToken(null);
+    if (typeof window !== 'undefined') {
+      window.location.href = '/login';
+    }
+    throw new ApiException(401, 'Session expired. Please log in again.');
+  }
 
   if (!response.ok) {
     const error: ApiError = await response.json().catch(() => ({

--- a/apps/web/src/lib/budgets.test.ts
+++ b/apps/web/src/lib/budgets.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { budgetsApi } from './budgets';
 import { BudgetType } from '@/types';
-import { ApiException } from './api';
+import { ApiException, setAccessToken } from './api';
 import { mockToken } from '@/test/mocks/handlers';
 
 describe('budgetsApi', () => {
   beforeEach(() => {
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+    setAccessToken(mockToken);
   });
 
   describe('getAll', () => {
@@ -24,7 +24,7 @@ describe('budgetsApi', () => {
     });
 
     it('should throw ApiException on 401', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       await expect(budgetsApi.getAll()).rejects.toThrow(ApiException);
     });
@@ -78,7 +78,7 @@ describe('budgetsApi', () => {
     });
 
     it('should throw ApiException on 401', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       await expect(budgetsApi.getDetails('budget-1')).rejects.toThrow(
         ApiException,
@@ -107,7 +107,7 @@ describe('budgetsApi', () => {
     });
 
     it('should throw ApiException on 401', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       await expect(budgetsApi.getByCategory('cat-2')).rejects.toThrow(
         ApiException,

--- a/apps/web/src/lib/transactions.test.ts
+++ b/apps/web/src/lib/transactions.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { transactionsApi } from './transactions';
 import { TransactionType } from '@/types';
-import { ApiException } from './api';
+import { ApiException, setAccessToken } from './api';
 import { mockToken } from '@/test/mocks/handlers';
 
 describe('transactionsApi', () => {
   beforeEach(() => {
-    vi.mocked(localStorage.getItem).mockReturnValue(mockToken);
+    setAccessToken(mockToken);
   });
 
   describe('getAll', () => {
@@ -23,7 +23,7 @@ describe('transactionsApi', () => {
     });
 
     it('should throw ApiException on 401', async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+      setAccessToken(null);
 
       await expect(transactionsApi.getAll()).rejects.toThrow(ApiException);
     });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const PROTECTED_ROUTES = [
+  '/dashboard',
+  '/categories',
+  '/transactions',
+  '/budgets',
+];
+
+export function middleware(request: NextRequest) {
+  const isProtected = PROTECTED_ROUTES.some((r) =>
+    request.nextUrl.pathname.startsWith(r),
+  );
+
+  if (!isProtected) return NextResponse.next();
+
+  const refreshToken = request.cookies.get('refresh_token');
+  if (!refreshToken) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/dashboard/:path*',
+    '/categories/:path*',
+    '/transactions/:path*',
+    '/budgets/:path*',
+  ],
+};

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -167,12 +167,17 @@ export const mockTopExpenses = [
 export const mockToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZXN0LXVzZXItaWQiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJuYW1lIjoiVGVzdCBVc2VyIiwiaWF0IjoxNzA0MDY3MjAwfQ.fake-signature';
 
+export const mockRefreshToken = 'mock-refresh-token-value';
+
 export const handlers = [
   // Auth endpoints
   http.post(`${API_URL}/auths/login`, async ({ request }) => {
     const body = (await request.json()) as { email: string; password: string };
     if (body.email === 'test@example.com' && body.password === 'password123') {
-      return HttpResponse.json({ access_token: mockToken });
+      return HttpResponse.json({
+        access_token: mockToken,
+        refresh_token: mockRefreshToken,
+      });
     }
     return HttpResponse.json(
       { message: 'Invalid credentials', statusCode: 401 },
@@ -188,7 +193,28 @@ export const handlers = [
         { status: 409 },
       );
     }
-    return HttpResponse.json({ access_token: mockToken });
+    return HttpResponse.json({
+      access_token: mockToken,
+      refresh_token: mockRefreshToken,
+    });
+  }),
+
+  http.post(`${API_URL}/auths/refresh`, async ({ request }) => {
+    const body = (await request.json()) as { refresh_token: string };
+    if (body.refresh_token === mockRefreshToken) {
+      return HttpResponse.json({
+        access_token: mockToken,
+        refresh_token: mockRefreshToken,
+      });
+    }
+    return HttpResponse.json(
+      { message: 'Invalid refresh token', statusCode: 401 },
+      { status: 401 },
+    );
+  }),
+
+  http.post(`${API_URL}/auths/logout`, () => {
+    return new HttpResponse(null, { status: 204 });
   }),
 
   // Categories endpoints

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach, beforeAll, afterAll, vi, beforeEach } from 'vitest';
 import { server } from './mocks/server';
+import { setAccessToken } from '@/lib/api';
 
 // Suppress React act() warnings from Radix UI components
 // These warnings occur due to Radix UI's internal async state management
@@ -99,6 +100,10 @@ afterEach(() => {
   localStorageMock.getItem.mockReset();
   localStorageMock.setItem.mockReset();
   localStorageMock.removeItem.mockReset();
+  // Clear the module-level access token between tests
+  setAccessToken(null);
+  // Clear the refresh token cookie between tests
+  document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
 });
 
 afterAll(() => server.close());

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -3,7 +3,9 @@ import { render, RenderOptions, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, expect } from 'vitest';
 import { NextIntlClientProvider } from 'next-intl';
-import { AuthProvider } from '@/contexts/AuthContext';
+import { AuthProvider, AuthContext } from '@/contexts/AuthContext';
+import { setAccessToken } from '@/lib/api';
+import { mockToken, mockUser } from '@/test/mocks/handlers';
 import enMessages from '../../messages/en.json';
 
 interface WrapperProps {
@@ -18,11 +20,46 @@ function AllProviders({ children }: WrapperProps) {
   );
 }
 
+// Mock auth context value for authenticated tests — avoids async session restore
+const mockAuthContextValue = {
+  user: mockUser,
+  token: mockToken,
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+};
+
+function AuthenticatedProviders({ children }: WrapperProps) {
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AuthContext.Provider value={mockAuthContextValue}>
+        {children}
+      </AuthContext.Provider>
+    </NextIntlClientProvider>
+  );
+}
+
 export function renderWithProviders(
   ui: React.ReactElement,
   options?: Omit<RenderOptions, 'wrapper'>,
 ) {
   return render(ui, { wrapper: AllProviders, ...options });
+}
+
+/**
+ * Renders a component with a synchronously authenticated auth context.
+ * Use this for all authenticated pages/components (dashboard, categories, etc.)
+ * to avoid the async session restore delay.
+ * Also sets the module-level access token so API calls include the auth header.
+ */
+export function renderWithAuthenticatedProviders(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) {
+  setAccessToken(mockToken);
+  return render(ui, { wrapper: AuthenticatedProviders, ...options });
 }
 
 /**

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -42,6 +42,7 @@ export interface RegisterRequest {
 
 export interface AuthResponse {
   access_token: string;
+  refresh_token: string;
 }
 
 // Budget types


### PR DESCRIPTION
…and route guard

- Move access token to memory (React state) and refresh token to cookie instead of storing access token in localStorage (prevents XSS theft)
- Add 401 interceptor in api.ts with automatic token refresh and retry logic
- Add POST /auths/logout call on logout for server-side token revocation
- Add restoreSession on mount: reads refresh token cookie and silently re-authenticates to restore session across page reloads
- Add Next.js middleware for server-side route protection on all protected routes (dashboard, categories, transactions, budgets)
- Add security headers in next.config.mjs: X-Frame-Options, CSP, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy
- Remove raw error.message display from ErrorBoundary (prevents info leakage)
- Update AuthResponse type to include refresh_token field
- Update all tests: replace localStorage mock with setAccessToken helper, add renderWithAuthenticatedProviders for authenticated page tests, rewrite AuthContext tests for cookie-based session behavior, add /auths/refresh and /auths/logout MSW handlers