### PR TITLE
feat(budgets): auto-derive budget type from category

### DIFF
--- a/apps/api/src/i18n/en/budgets.json
+++ b/apps/api/src/i18n/en/budgets.json
@@ -2,7 +2,7 @@
   "errors": {
     "notFound": "Budget with ID {id} not found",
     "categoryNotFound": "Category with ID {id} does not exist",
-    "alreadyExists": "Budget for category {categoryId}, type {type}, month {month}, and year {year} already exists",
+    "alreadyExists": "Budget for category {categoryName}, type {type}, month {month}, and year {year} already exists",
     "invalidType": "Invalid budget type: {type}",
     "invalidMonth": "Month must be between 1 and 12"
   }

--- a/apps/api/src/i18n/pt-BR/budgets.json
+++ b/apps/api/src/i18n/pt-BR/budgets.json
@@ -2,7 +2,7 @@
   "errors": {
     "notFound": "Orçamento com ID {id} não encontrado",
     "categoryNotFound": "Categoria com ID {id} não existe",
-    "alreadyExists": "Orçamento para categoria {categoryId}, tipo {type}, mês {month}, e ano {year} já existe",
+    "alreadyExists": "Orçamento para categoria {categoryName}, tipo {type}, mês {month}, e ano {year} já existe",
     "invalidType": "Tipo de orçamento inválido: {type}",
     "invalidMonth": "O mês deve estar entre 1 e 12"
   }

--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -286,7 +286,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const result = await service.createBudget(createDto, userId);
@@ -295,6 +294,7 @@ describe('BudgetService', () => {
         ...createDto,
         amount: '500.00',
         id: result.id,
+        type: BudgetType.EXPENSE,
       });
       expect(categoriesService.getCategoryById).toHaveBeenCalledWith(
         categoryId,
@@ -308,7 +308,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 0,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       await expect(service.createBudget(createDto, userId)).rejects.toThrow(
@@ -325,7 +324,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 13,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       await expect(service.createBudget(createDto, userId)).rejects.toThrow(
@@ -350,7 +348,6 @@ describe('BudgetService', () => {
         categoryId: otherCategoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       await expect(service.createBudget(createDto, userId)).rejects.toThrow(
@@ -367,7 +364,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       await service.createBudget(createDto, userId);
@@ -386,7 +382,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const createDto2: CreateBudgetDto = {
@@ -394,7 +389,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 2,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const result1 = await service.createBudget(createDto1, userId);
@@ -412,7 +406,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
     });
@@ -514,7 +507,6 @@ describe('BudgetService', () => {
         categoryId: otherCategoryId,
         month: 2,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto2, userId);
 
@@ -553,7 +545,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
 
@@ -629,7 +620,6 @@ describe('BudgetService', () => {
         categoryId: otherCategoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       const budget2 = await service.createBudget(createDto2, userId);
 
@@ -646,7 +636,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
 
@@ -703,7 +692,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
     });
@@ -739,7 +727,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 2,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       const budget = await service.createBudget(createDto, userId);
 
@@ -795,12 +782,15 @@ describe('BudgetService', () => {
 
     describe('INCOME budgets', () => {
       it('should return earned field instead of spent for INCOME budgets', async () => {
+        jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+          ...buildCategory(categoryId, 'Groceries', userId),
+          type: CategoryType.INCOME,
+        });
         const createDto: CreateBudgetDto = {
           amount: 1000,
           categoryId,
           month: 3,
           year: 2026,
-          type: BudgetType.INCOME,
         };
         const budget = await service.createBudget(createDto, userId);
 
@@ -830,12 +820,15 @@ describe('BudgetService', () => {
       });
 
       it('should calculate INCOME utilization correctly with multiple transactions', async () => {
+        jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+          ...buildCategory(categoryId, 'Groceries', userId),
+          type: CategoryType.INCOME,
+        });
         const createDto: CreateBudgetDto = {
           amount: 2000,
           categoryId,
           month: 4,
           year: 2026,
-          type: BudgetType.INCOME,
         };
         const budget = await service.createBudget(createDto, userId);
 
@@ -880,7 +873,6 @@ describe('BudgetService', () => {
           categoryId,
           month: 5,
           year: 2026,
-          type: BudgetType.EXPENSE,
         };
         const budget = await service.createBudget(createDto, userId);
 
@@ -917,7 +909,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
     });
@@ -971,7 +962,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       await service.createBudget(createDto, userId);
 
@@ -1079,12 +1069,15 @@ describe('BudgetService', () => {
 
     describe('INCOME budgets', () => {
       it('should return earned field instead of spent for INCOME budget with transactions', async () => {
+        jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+          ...buildCategory(categoryId, 'Groceries', userId),
+          type: CategoryType.INCOME,
+        });
         const createDto: CreateBudgetDto = {
           amount: 3000,
           categoryId,
           month: 6,
           year: 2026,
-          type: BudgetType.INCOME,
         };
         const budget = await service.createBudget(createDto, userId);
 
@@ -1134,7 +1127,6 @@ describe('BudgetService', () => {
           categoryId,
           month: 7,
           year: 2026,
-          type: BudgetType.EXPENSE,
         };
         const budget = await service.createBudget(createDto, userId);
 
@@ -1174,7 +1166,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget1 = await service.createBudget(createDto, userId);
@@ -1193,7 +1184,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       await service.createBudget(createDto, userId);
@@ -1214,7 +1204,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1230,7 +1219,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1250,7 +1238,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1266,7 +1253,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1282,7 +1268,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1298,7 +1283,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1314,7 +1298,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1356,7 +1339,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1372,7 +1354,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const budget = await service.createBudget(createDto, userId);
@@ -1412,7 +1393,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       const budget = await service.createBudget(createDto, userId);
 
@@ -1428,7 +1408,6 @@ describe('BudgetService', () => {
         categoryId,
         month: 1,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
       const budget = await service.createBudget(createDto, userId);
       const result = await service.getBudgetWithSpending(budget.id, userId);
@@ -1457,12 +1436,15 @@ describe('BudgetService', () => {
     });
 
     it('should serialize earned field as fixed-precision string for INCOME budgets', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        ...buildCategory(categoryId, 'Groceries', userId),
+        type: CategoryType.INCOME,
+      });
       const createDto: CreateBudgetDto = {
         amount: 1000,
         categoryId,
         month: 2,
         year: 2026,
-        type: BudgetType.INCOME,
       };
       const budget = await service.createBudget(createDto, userId);
       const result = await service.getBudgetWithSpending(budget.id, userId);

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -122,25 +122,6 @@ export class BudgetService {
     description: true,
   };
 
-  private normalizeBudgetType(type: string): BudgetType {
-    const normalized = type?.toUpperCase();
-
-    if (normalized === BudgetType.EXPENSE) {
-      return BudgetType.EXPENSE;
-    }
-
-    if (normalized === BudgetType.INCOME) {
-      return BudgetType.INCOME;
-    }
-
-    throw new BadRequestException(
-      this.i18n.t('budgets.errors.invalidType', {
-        args: { type },
-        lang: this.lang,
-      }),
-    );
-  }
-
   private mapBudget(budget: {
     id: string;
     amount: { toString(): string };
@@ -274,7 +255,7 @@ export class BudgetService {
           categoryId: budgetData.categoryId,
           month: budgetData.month,
           year: budgetData.year,
-          type: this.normalizeBudgetType(budgetData.type),
+          type: category.type as unknown as BudgetType,
           userId,
         },
         select: this.budgetSelect,
@@ -289,8 +270,8 @@ export class BudgetService {
         throw new ConflictException(
           this.i18n.t('budgets.errors.alreadyExists', {
             args: {
-              categoryId: budgetData.categoryId,
-              type: budgetData.type,
+              categoryName: category.name,
+              type: category.type,
               month: budgetData.month,
               year: budgetData.year,
             },
@@ -319,11 +300,13 @@ export class BudgetService {
 
     if (
       budgetData.month !== undefined ||
-      budgetData.year !== undefined ||
-      budgetData.type !== undefined
+      budgetData.year !== undefined
     ) {
       this.validateBudgetDataPartial(budgetData);
     }
+
+    let newType: BudgetType | undefined;
+    let categoryName: string | undefined;
 
     if (budgetData.categoryId !== undefined) {
       let category = null;
@@ -346,6 +329,8 @@ export class BudgetService {
           }),
         );
       }
+      newType = category.type as unknown as BudgetType;
+      categoryName = category.name;
     }
 
     try {
@@ -356,10 +341,7 @@ export class BudgetService {
           categoryId: budgetData.categoryId,
           month: budgetData.month,
           year: budgetData.year,
-          type:
-            budgetData.type !== undefined
-              ? this.normalizeBudgetType(budgetData.type)
-              : undefined,
+          type: newType,
         },
         select: this.budgetSelect,
       });
@@ -370,16 +352,29 @@ export class BudgetService {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {
+        const resolvedCategoryId =
+          budgetData.categoryId ?? existingBudget.categoryId;
+        if (!categoryName) {
+          try {
+            const cat = await this.categoriesService.getCategoryById(
+              resolvedCategoryId,
+              userId,
+            );
+            categoryName = cat?.name;
+          } catch {
+            categoryName = resolvedCategoryId;
+          }
+        }
         const payload = {
-          categoryId: budgetData.categoryId ?? existingBudget.categoryId,
-          type: budgetData.type ?? existingBudget.type,
+          categoryName: categoryName ?? resolvedCategoryId,
+          type: newType ?? existingBudget.type,
           month: budgetData.month ?? existingBudget.month,
           year: budgetData.year ?? existingBudget.year,
         };
         throw new ConflictException(
           this.i18n.t('budgets.errors.alreadyExists', {
             args: {
-              categoryId: payload.categoryId,
+              categoryName: payload.categoryName,
               type: payload.type,
               month: payload.month,
               year: payload.year,

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -298,10 +298,7 @@ export class BudgetService {
       );
     }
 
-    if (
-      budgetData.month !== undefined ||
-      budgetData.year !== undefined
-    ) {
+    if (budgetData.month !== undefined || budgetData.year !== undefined) {
       this.validateBudgetDataPartial(budgetData);
     }
 

--- a/apps/api/src/modules/budgets/dto/create-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/create-budget.dto.ts
@@ -1,6 +1,5 @@
-import { IsEnum, IsNumber, IsUUID } from 'class-validator';
+import { IsNumber, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { BudgetType } from '@prisma/client';
 
 export class CreateBudgetDto {
   @ApiProperty({
@@ -33,12 +32,4 @@ export class CreateBudgetDto {
   })
   @IsNumber()
   year: number;
-
-  @ApiProperty({
-    description: 'Budget type',
-    enum: BudgetType,
-    example: BudgetType.EXPENSE,
-  })
-  @IsEnum(BudgetType)
-  type: BudgetType;
 }

--- a/apps/api/src/modules/budgets/dto/update-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/update-budget.dto.ts
@@ -1,6 +1,5 @@
-import { IsEnum, IsNumber, IsOptional, IsUUID } from 'class-validator';
+import { IsNumber, IsOptional, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { BudgetType } from '@prisma/client';
 
 export class UpdateBudgetDto {
   @ApiProperty({
@@ -40,14 +39,4 @@ export class UpdateBudgetDto {
   @IsOptional()
   @IsNumber()
   year?: number;
-
-  @ApiProperty({
-    description: 'Budget type',
-    enum: BudgetType,
-    example: BudgetType.EXPENSE,
-    required: false,
-  })
-  @IsOptional()
-  @IsEnum(BudgetType)
-  type?: BudgetType;
 }

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -761,7 +761,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 1,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(201);
 
@@ -780,7 +779,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 1,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(401);
       });
@@ -794,7 +792,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 13,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(400);
       });
@@ -808,7 +805,6 @@ describe('Personal Finance API E2E', () => {
             categoryId: '00000000-0000-0000-0000-000000000000',
             month: 1,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(400);
       });
@@ -823,7 +819,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 2,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(201);
 
@@ -836,7 +831,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 2,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(409);
       });
@@ -876,7 +870,6 @@ describe('Personal Finance API E2E', () => {
             categoryId: testCatId,
             month: 3,
             year: 2026,
-            type: 'EXPENSE',
           });
 
         expect(budgetResponse.status).toBe(201);
@@ -937,7 +930,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 1,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(200);
 
@@ -953,7 +945,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 1,
             year: 2026,
-            type: 'EXPENSE',
           })
           .expect(404);
       });
@@ -970,7 +961,6 @@ describe('Personal Finance API E2E', () => {
             categoryId,
             month: 5,
             year: 2026,
-            type: 'EXPENSE',
           });
 
         const budgetToDeleteId = createResponse.body.id;

--- a/apps/web/src/app/budgets/[id]/edit/page.tsx
+++ b/apps/web/src/app/budgets/[id]/edit/page.tsx
@@ -71,7 +71,6 @@ export default function EditBudgetPage() {
               categoryId: budget.categoryId,
               month: budget.month,
               year: budget.year,
-              type: budget.type,
             }}
             onSubmit={handleUpdate}
           />

--- a/apps/web/src/app/budgets/new/page.test.tsx
+++ b/apps/web/src/app/budgets/new/page.test.tsx
@@ -39,7 +39,6 @@ describe('NewBudgetPage', () => {
     expect(screen.getByLabelText('Category')).toBeInTheDocument();
     expect(screen.getByLabelText('Month')).toBeInTheDocument();
     expect(screen.getByLabelText('Year')).toBeInTheDocument();
-    expect(screen.getByLabelText('Type')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/BudgetForm.test.tsx
+++ b/apps/web/src/components/BudgetForm.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderWithProviders, setupUser } from '@/test/test-utils';
 import { BudgetForm } from './BudgetForm';
-import { BudgetType } from '@/types';
 import { ApiException } from '@/lib/api';
 
 // Mock sonner toast
@@ -83,7 +82,6 @@ describe('BudgetForm', () => {
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
     expect(screen.getByLabelText('Month')).toBeInTheDocument();
     expect(screen.getByLabelText('Year')).toBeInTheDocument();
-    expect(screen.getByLabelText('Type')).toBeInTheDocument();
   });
 
   it('should load categories in dropdown', async () => {
@@ -124,7 +122,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -160,7 +157,6 @@ describe('BudgetForm', () => {
           categoryId: '',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -170,30 +166,6 @@ describe('BudgetForm', () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Category is required');
-    });
-    expect(mockOnSubmit).not.toHaveBeenCalled();
-  });
-
-  it('should show error toast when type is not selected', async () => {
-    renderWithProviders(
-      <BudgetForm
-        title="Create Budget"
-        submitLabel="Create"
-        initialData={{
-          amount: 500,
-          categoryId: 'cat-2',
-          month: 3,
-          year: 2026,
-          type: '' as BudgetType,
-        }}
-        onSubmit={mockOnSubmit}
-      />,
-    );
-
-    fireEvent.submit(document.querySelector('form')!);
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Type is required');
     });
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
@@ -208,7 +180,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -222,7 +193,6 @@ describe('BudgetForm', () => {
         categoryId: 'cat-2',
         month: 3,
         year: 2026,
-        type: BudgetType.EXPENSE,
       });
     });
 
@@ -240,7 +210,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -267,7 +236,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -294,7 +262,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -320,7 +287,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,
@@ -363,7 +329,6 @@ describe('BudgetForm', () => {
           categoryId: 'cat-2',
           month: 3,
           year: 2026,
-          type: BudgetType.EXPENSE,
         }}
         onSubmit={mockOnSubmit}
       />,

--- a/apps/web/src/components/BudgetForm.tsx
+++ b/apps/web/src/components/BudgetForm.tsx
@@ -20,7 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { BudgetType, CreateBudgetDto, Category } from '@/types';
+import { CreateBudgetDto, Category } from '@/types';
 import { toast } from 'sonner';
 import { ApiException } from '@/lib/api';
 import { categoriesApi } from '@/lib/categories';
@@ -31,7 +31,6 @@ interface BudgetFormProps {
     categoryId: string;
     month: number;
     year: number;
-    type: BudgetType;
   };
   onSubmit: (data: CreateBudgetDto) => Promise<unknown>;
   title: string;
@@ -54,7 +53,6 @@ export function BudgetForm({
   const [year, setYear] = useState<string>(
     initialData?.year?.toString() || new Date().getFullYear().toString(),
   );
-  const [type, setType] = useState<BudgetType | ''>(initialData?.type || '');
   const [isLoading, setIsLoading] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoadingCategories, setIsLoadingCategories] = useState(true);
@@ -113,11 +111,6 @@ export function BudgetForm({
       return;
     }
 
-    if (!type) {
-      toast.error(t('typeRequired'));
-      return;
-    }
-
     setIsLoading(true);
     try {
       await onSubmit({
@@ -125,7 +118,6 @@ export function BudgetForm({
         categoryId,
         month: month as number,
         year: yearNum,
-        type,
       });
       toast.success(initialData ? t('updateSuccess') : t('createSuccess'));
       router.push('/budgets');
@@ -225,26 +217,6 @@ export function BudgetForm({
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="type">{tCommon('type')}</Label>
-            <Select
-              value={type}
-              onValueChange={(value) => setType(value as BudgetType)}
-              disabled={isLoading}
-            >
-              <SelectTrigger id="type">
-                <SelectValue placeholder={t('selectType')} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={BudgetType.INCOME}>
-                  {tCommon('income')}
-                </SelectItem>
-                <SelectItem value={BudgetType.EXPENSE}>
-                  {tCommon('expense')}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
         </CardContent>
         <CardFooter className="mt-4 flex justify-between">
           <Button

--- a/apps/web/src/lib/budgets.test.ts
+++ b/apps/web/src/lib/budgets.test.ts
@@ -122,7 +122,6 @@ describe('budgetsApi', () => {
         categoryId: 'cat-1',
         month: 3,
         year: 2026,
-        type: BudgetType.EXPENSE,
       };
 
       const result = await budgetsApi.create(newBudget);
@@ -132,7 +131,7 @@ describe('budgetsApi', () => {
       expect(result.categoryId).toBe('cat-1');
       expect(result.month).toBe(3);
       expect(result.year).toBe(2026);
-      expect(result.type).toBe(BudgetType.EXPENSE);
+      expect(result.type).toBe(BudgetType.INCOME);
     });
   });
 

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -366,15 +366,15 @@ export const handlers = [
       categoryId: string;
       month: number;
       year: number;
-      type: string;
     };
+    const category = mockCategories.find((c) => c.id === body.categoryId);
     return HttpResponse.json({
       id: 'new-budget-id',
       amount: body.amount.toFixed(2),
       categoryId: body.categoryId,
       month: body.month,
       year: body.year,
-      type: body.type,
+      type: category?.type ?? 'EXPENSE',
       userId: 'test-user-id',
     });
   }),
@@ -399,7 +399,6 @@ export const handlers = [
       categoryId?: string;
       month?: number;
       year?: number;
-      type?: string;
     };
     return HttpResponse.json({
       ...budget,
@@ -408,7 +407,6 @@ export const handlers = [
       categoryId: body.categoryId ?? budget.categoryId,
       month: body.month ?? budget.month,
       year: body.year ?? budget.year,
-      type: body.type ?? budget.type,
     });
   }),
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -66,7 +66,6 @@ export interface CreateBudgetDto {
   categoryId: string;
   month: number;
   year: number;
-  type: BudgetType;
 }
 
 export interface UpdateBudgetDto {
@@ -74,7 +73,6 @@ export interface UpdateBudgetDto {
   categoryId?: string;
   month?: number;
   year?: number;
-  type?: BudgetType;
 }
 
 interface BudgetWithSpendingBase {


### PR DESCRIPTION
Remove the `type` field from CreateBudgetDto and UpdateBudgetDto. The budget type is now derived automatically from the selected category on create (and updated when the category is changed on update), eliminating redundant user input since every category already carries a type.

Also improve the duplicate-budget error message to show the category name instead of its UUID.