### PR TITLE
feat(transactions): auto-derive transaction type from category

### DIFF
--- a/apps/api/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/apps/api/src/modules/transactions/dto/create-transaction.dto.ts
@@ -20,14 +20,6 @@ export class CreateTransactionDto {
   amount: number;
 
   @ApiProperty({
-    description: 'Transaction type',
-    example: 'EXPENSE',
-  })
-  @IsString()
-  @MaxLength(20)
-  type: string;
-
-  @ApiProperty({
     description: 'Category UUID',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })

--- a/apps/api/src/modules/transactions/dto/update-transaction.dto.ts
+++ b/apps/api/src/modules/transactions/dto/update-transaction.dto.ts
@@ -19,16 +19,6 @@ export class UpdateTransactionDto {
   amount?: number;
 
   @ApiProperty({
-    description: 'Transaction type',
-    example: 'EXPENSE',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(20)
-  type?: string;
-
-  @ApiProperty({
     description: 'Category UUID',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false,

--- a/apps/api/src/modules/transactions/transactions.service.spec.ts
+++ b/apps/api/src/modules/transactions/transactions.service.spec.ts
@@ -157,7 +157,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -190,7 +189,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -215,7 +213,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -236,7 +233,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -260,7 +256,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -283,7 +278,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId: otherCategoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -304,7 +298,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -316,6 +309,38 @@ describe('TransactionsService', () => {
       expect(allTransactions.length).toBe(1);
       expect(allTransactions[0].amount).toBe('1000.00');
     });
+
+    it('should derive INCOME type from INCOME category', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        ...buildCategory(categoryId, 'Salary'),
+        type: CategoryType.INCOME,
+      });
+
+      const createDto: CreateTransactionDto = {
+        amount: 1000,
+        categoryId,
+        date: '2025-01-01',
+      };
+
+      const transaction = await service.createTransaction(createDto, userId);
+      expect(transaction.type).toBe(TransactionType.INCOME);
+    });
+
+    it('should derive EXPENSE type from EXPENSE category', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        ...buildCategory(categoryId, 'Groceries'),
+        type: CategoryType.EXPENSE,
+      });
+
+      const createDto: CreateTransactionDto = {
+        amount: 50,
+        categoryId,
+        date: '2025-01-01',
+      };
+
+      const transaction = await service.createTransaction(createDto, userId);
+      expect(transaction.type).toBe(TransactionType.EXPENSE);
+    });
   });
 
   describe('updateTransaction', () => {
@@ -326,7 +351,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -370,7 +394,6 @@ describe('TransactionsService', () => {
       const updateDto: UpdateTransactionDto = {
         amount: 2000,
         description: 'Bonus payment',
-        type: 'expense',
       };
 
       const [existing] = await service.getAllTransactions(userId);
@@ -385,14 +408,13 @@ describe('TransactionsService', () => {
       }
       expect(updated.amount).toBe('2000.00');
       expect(updated.description).toBe('Bonus payment');
-      expect(updated.type).toBe(TransactionType.EXPENSE);
+      expect(updated.type).toBe(TransactionType.INCOME);
       expect(updated.date).toBe('2025-01-01T00:00:00.000Z');
     });
 
     it('should validate category when updating categoryId', async () => {
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -456,7 +478,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -479,6 +500,57 @@ describe('TransactionsService', () => {
         throw new Error('Expected updated transaction to be defined');
       }
       expect(updated.categoryId).toBe(otherCategoryId);
+    });
+
+    it('should update type to match new category type when categoryId changes', async () => {
+      jest
+        .spyOn(categoriesService, 'getCategoryById')
+        .mockResolvedValueOnce({
+          ...buildCategory(categoryId, 'Salary'),
+          type: CategoryType.INCOME,
+        })
+        .mockResolvedValueOnce({
+          ...buildCategory(otherCategoryId, 'Groceries'),
+          type: CategoryType.EXPENSE,
+        });
+
+      const createDto: CreateTransactionDto = {
+        amount: 1000,
+        categoryId,
+        date: '2025-01-01',
+      };
+
+      await service.createTransaction(createDto, userId);
+
+      const [existing] = await service.getAllTransactions(userId);
+      expect(existing.type).toBe(TransactionType.INCOME);
+
+      const updated = await service.updateTransaction(
+        existing.id,
+        { categoryId: otherCategoryId },
+        userId,
+      );
+
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
+      expect(updated.type).toBe(TransactionType.EXPENSE);
+    });
+
+    it('should not change type when categoryId is not updated', async () => {
+      const [existing] = await service.getAllTransactions(userId);
+      expect(existing.type).toBe(TransactionType.INCOME);
+
+      const updated = await service.updateTransaction(
+        existing.id,
+        { amount: 9999 },
+        userId,
+      );
+
+      if (!updated) {
+        throw new Error('Expected updated transaction to be defined');
+      }
+      expect(updated.type).toBe(TransactionType.INCOME);
     });
 
     it('should return null when user tries to update another users transaction', async () => {
@@ -508,7 +580,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',
@@ -550,7 +621,6 @@ describe('TransactionsService', () => {
 
       const createDto: CreateTransactionDto = {
         amount: 1000,
-        type: 'income',
         categoryId,
         date: '2025-01-01',
         description: 'Monthly salary',

--- a/apps/api/src/modules/transactions/transactions.service.ts
+++ b/apps/api/src/modules/transactions/transactions.service.ts
@@ -23,22 +23,6 @@ export class TransactionsService {
     return I18nContext.current()?.lang ?? 'en';
   }
 
-  private normalizeTransactionType(type: string): TransactionType {
-    const normalized = type?.toUpperCase();
-    if (normalized === TransactionType.INCOME) {
-      return TransactionType.INCOME;
-    }
-    if (normalized === TransactionType.EXPENSE) {
-      return TransactionType.EXPENSE;
-    }
-    throw new BadRequestException(
-      this.i18n.t('transactions.errors.invalidType', {
-        args: { type },
-        lang: this.lang,
-      }),
-    );
-  }
-
   private mapTransaction(transaction: {
     id: string;
     amount: { toString(): string };
@@ -118,7 +102,7 @@ export class TransactionsService {
     const newTransaction = await this.prisma.transaction.create({
       data: {
         amount: createTransactionDto.amount,
-        type: this.normalizeTransactionType(createTransactionDto.type),
+        type: category.type as unknown as TransactionType,
         categoryId: createTransactionDto.categoryId,
         date: new Date(createTransactionDto.date),
         description: createTransactionDto.description,
@@ -149,6 +133,7 @@ export class TransactionsService {
     }
 
     // Validate category existence if categoryId is being updated
+    let newType: TransactionType | undefined;
     if (updateTransactionDto.categoryId !== undefined) {
       let category = null;
 
@@ -171,16 +156,15 @@ export class TransactionsService {
           }),
         );
       }
+
+      newType = category.type as unknown as TransactionType;
     }
 
     const updatedTransaction = await this.prisma.transaction.update({
       where: { id, userId },
       data: {
         amount: updateTransactionDto.amount,
-        type:
-          updateTransactionDto.type !== undefined
-            ? this.normalizeTransactionType(updateTransactionDto.type)
-            : undefined,
+        type: newType,
         categoryId: updateTransactionDto.categoryId,
         date:
           updateTransactionDto.date !== undefined

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -475,7 +475,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 50.5,
-            type: 'EXPENSE',
             categoryId: catId,
             date: '2026-01-15',
             description: 'Test transaction',
@@ -518,7 +517,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 50.5,
-            type: 'EXPENSE',
             categoryId,
             date: '2026-01-15',
             description: 'Weekly groceries',
@@ -539,7 +537,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 100,
-            type: 'INCOME',
             categoryId,
             date: '2026-01-16',
           })
@@ -554,7 +551,6 @@ describe('Personal Finance API E2E', () => {
           .post('/transactions')
           .send({
             amount: 100,
-            type: 'INCOME',
             categoryId,
             date: '2026-01-15',
           })
@@ -567,7 +563,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 100,
-            type: 'INCOME',
             categoryId: '00000000-0000-0000-0000-000000000000',
             date: '2026-01-15',
           })
@@ -590,7 +585,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 100,
-            type: 'EXPENSE',
             categoryId: user2CatResponse.body.id,
             date: '2026-01-15',
           })
@@ -603,7 +597,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: -50,
-            type: 'EXPENSE',
             categoryId,
             date: '2026-01-15',
           })
@@ -667,7 +660,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 75.5,
-            type: 'EXPENSE',
             categoryId,
             date: '2026-01-20',
             description: 'Updated groceries',
@@ -692,7 +684,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 100,
-            type: 'EXPENSE',
             categoryId: user2CatResponse.body.id,
             date: '2026-01-15',
           })
@@ -705,7 +696,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user2Token}`)
           .send({
             amount: 999,
-            type: 'EXPENSE',
             categoryId,
             date: '2026-01-15',
           })
@@ -721,7 +711,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 25,
-            type: 'EXPENSE',
             categoryId,
             date: '2026-01-15',
           });
@@ -853,7 +842,6 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .send({
             amount: 1000,
-            type: 'EXPENSE',
             categoryId: testCatId,
             date: '2026-03-15',
           });
@@ -1155,7 +1143,6 @@ describe('Personal Finance API E2E', () => {
         .set('Authorization', `Bearer ${user2Token}`)
         .send({
           amount: 999,
-          type: 'EXPENSE',
           categoryId,
           date: '2026-01-15',
         })
@@ -1184,7 +1171,6 @@ describe('Personal Finance API E2E', () => {
         .set('Authorization', `Bearer ${user1Token}`)
         .send({
           amount: 200,
-          type: 'EXPENSE',
           categoryId: user1Category.body.id,
           date: '2026-04-15',
         });
@@ -1202,7 +1188,6 @@ describe('Personal Finance API E2E', () => {
         .set('Authorization', `Bearer ${user2Token}`)
         .send({
           amount: 50,
-          type: 'EXPENSE',
           categoryId: user2Category.body.id,
           date: '2026-04-15',
         });

--- a/apps/web/src/app/transactions/[id]/edit/page.tsx
+++ b/apps/web/src/app/transactions/[id]/edit/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { transactionsApi } from '@/lib/transactions';
 import { TransactionForm } from '@/components/TransactionForm';
 import { AuthLayout } from '@/components/layouts/AuthLayout';
-import { Transaction, UpdateTransactionDto, TransactionType } from '@/types';
+import { Transaction, UpdateTransactionDto } from '@/types';
 import { toast } from 'sonner';
 import { ApiException } from '@/lib/api';
 
@@ -74,7 +74,6 @@ export default function EditTransactionPage() {
             submitLabel={tCommon('save')}
             initialData={{
               amount: parseFloat(transaction.amount),
-              type: transaction.type as TransactionType,
               categoryId: transaction.categoryId,
               date: formatDateForInput(transaction.date),
               description: transaction.description,

--- a/apps/web/src/app/transactions/new/page.test.tsx
+++ b/apps/web/src/app/transactions/new/page.test.tsx
@@ -36,7 +36,6 @@ describe('NewTransactionPage', () => {
 
     // Check form fields are present
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
-    expect(screen.getByLabelText('Type')).toBeInTheDocument();
     expect(screen.getByLabelText('Date')).toBeInTheDocument();
     expect(screen.getByLabelText('Description (optional)')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();

--- a/apps/web/src/components/TransactionForm.test.tsx
+++ b/apps/web/src/components/TransactionForm.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderWithProviders, setupUser } from '@/test/test-utils';
 import { TransactionForm } from './TransactionForm';
-import { TransactionType } from '@/types';
 import { ApiException } from '@/lib/api';
 
 // Mock sonner toast
@@ -81,7 +80,6 @@ describe('TransactionForm', () => {
     );
 
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
-    expect(screen.getByLabelText('Type')).toBeInTheDocument();
     expect(screen.getByLabelText('Date')).toBeInTheDocument();
     expect(screen.getByLabelText('Description (optional)')).toBeInTheDocument();
   });
@@ -121,7 +119,6 @@ describe('TransactionForm', () => {
         submitLabel="Save"
         initialData={{
           amount: 150,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
           description: 'Test description',
@@ -157,7 +154,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: '',
           date: '2026-03-05',
         }}
@@ -173,29 +169,6 @@ describe('TransactionForm', () => {
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
-  it('should show error toast when type is not selected', async () => {
-    renderWithProviders(
-      <TransactionForm
-        title="Create Transaction"
-        submitLabel="Create"
-        initialData={{
-          amount: 100,
-          type: '' as TransactionType,
-          categoryId: 'cat-2',
-          date: '2026-03-05',
-        }}
-        onSubmit={mockOnSubmit}
-      />,
-    );
-
-    fireEvent.submit(document.querySelector('form')!);
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Type is required');
-    });
-    expect(mockOnSubmit).not.toHaveBeenCalled();
-  });
-
   it('should submit form with valid data from initialData', async () => {
     renderWithProviders(
       <TransactionForm
@@ -203,7 +176,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
           description: 'Test transaction',
@@ -217,7 +189,6 @@ describe('TransactionForm', () => {
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
         amount: 100,
-        type: TransactionType.EXPENSE,
         categoryId: 'cat-2',
         date: '2026-03-05T00:00:00.000Z',
         description: 'Test transaction',
@@ -237,7 +208,6 @@ describe('TransactionForm', () => {
         submitLabel="Save"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
         }}
@@ -265,7 +235,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
         }}
@@ -289,7 +258,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
         }}
@@ -314,7 +282,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
         }}
@@ -357,7 +324,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: -100,
-          type: TransactionType.EXPENSE,
           categoryId: 'cat-2',
           date: '2026-03-05',
         }}
@@ -380,7 +346,6 @@ describe('TransactionForm', () => {
         submitLabel="Create"
         initialData={{
           amount: 100,
-          type: TransactionType.INCOME,
           categoryId: 'cat-1',
           date: '2026-03-05',
         }}
@@ -393,7 +358,6 @@ describe('TransactionForm', () => {
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
         amount: 100,
-        type: TransactionType.INCOME,
         categoryId: 'cat-1',
         date: '2026-03-05T00:00:00.000Z',
         description: undefined,

--- a/apps/web/src/components/TransactionForm.tsx
+++ b/apps/web/src/components/TransactionForm.tsx
@@ -20,7 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { TransactionType, CreateTransactionDto, Category } from '@/types';
+import { CreateTransactionDto, Category } from '@/types';
 import { toast } from 'sonner';
 import { ApiException } from '@/lib/api';
 import { categoriesApi } from '@/lib/categories';
@@ -28,7 +28,6 @@ import { categoriesApi } from '@/lib/categories';
 interface TransactionFormProps {
   initialData?: {
     amount: number;
-    type: TransactionType;
     categoryId: string;
     date: string;
     description?: string;
@@ -46,9 +45,6 @@ export function TransactionForm({
 }: TransactionFormProps) {
   const [amount, setAmount] = useState<string>(
     initialData?.amount?.toString() || '',
-  );
-  const [type, setType] = useState<TransactionType | ''>(
-    initialData?.type || '',
   );
   const [categoryId, setCategoryId] = useState<string>(
     initialData?.categoryId || '',
@@ -93,11 +89,6 @@ export function TransactionForm({
       return;
     }
 
-    if (!type) {
-      toast.error(t('typeRequired'));
-      return;
-    }
-
     if (!categoryId) {
       toast.error(t('categoryRequired'));
       return;
@@ -112,7 +103,6 @@ export function TransactionForm({
     try {
       await onSubmit({
         amount: amountNum,
-        type,
         categoryId,
         date: new Date(date).toISOString(),
         description: description || undefined,
@@ -150,27 +140,6 @@ export function TransactionForm({
               required
               disabled={isLoading}
             />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="type">{tCommon('type')}</Label>
-            <Select
-              value={type}
-              onValueChange={(value) => setType(value as TransactionType)}
-              disabled={isLoading}
-            >
-              <SelectTrigger id="type">
-                <SelectValue placeholder={t('selectType')} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={TransactionType.INCOME}>
-                  {tCommon('income')}
-                </SelectItem>
-                <SelectItem value={TransactionType.EXPENSE}>
-                  {tCommon('expense')}
-                </SelectItem>
-              </SelectContent>
-            </Select>
           </div>
 
           <div className="space-y-2">

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -557,15 +557,15 @@ export const handlers = [
     }
     const body = (await request.json()) as {
       amount: number;
-      type: string;
       categoryId: string;
       date: string;
       description?: string;
     };
+    const category = mockCategories.find((c) => c.id === body.categoryId);
     return HttpResponse.json({
       id: 'new-transaction-id',
       amount: body.amount.toFixed(2),
-      type: body.type,
+      type: category?.type ?? 'EXPENSE',
       categoryId: body.categoryId,
       date: body.date,
       description: body.description,
@@ -592,17 +592,21 @@ export const handlers = [
     }
     const body = (await request.json()) as {
       amount?: number;
-      type?: string;
       categoryId?: string;
       date?: string;
       description?: string;
     };
+    const newCategoryId = body.categoryId ?? transaction.categoryId;
+    const newCategory = mockCategories.find((c) => c.id === newCategoryId);
     return HttpResponse.json({
       ...transaction,
       amount:
         body.amount !== undefined ? body.amount.toFixed(2) : transaction.amount,
-      type: body.type ?? transaction.type,
-      categoryId: body.categoryId ?? transaction.categoryId,
+      type:
+        body.categoryId !== undefined
+          ? (newCategory?.type ?? transaction.type)
+          : transaction.type,
+      categoryId: newCategoryId,
       date: body.date ?? transaction.date,
       description: body.description ?? transaction.description,
       updatedAt: new Date().toISOString(),

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -133,7 +133,6 @@ export interface Transaction {
 
 export interface CreateTransactionDto {
   amount: number;
-  type: TransactionType;
   categoryId: string;
   date: string;
   description?: string;
@@ -141,7 +140,6 @@ export interface CreateTransactionDto {
 
 export interface UpdateTransactionDto {
   amount?: number;
-  type?: TransactionType;
   categoryId?: string;
   date?: string;
   description?: string;


### PR DESCRIPTION
Remove the explicit `type` field from create/update transaction DTOs. The service now derives transaction type directly from the selected category, mirroring the existing budget module pattern.

- Remove `type` from CreateTransactionDto and UpdateTransactionDto
- Remove `normalizeTransactionType` helper (no longer needed)
- Derive type via `category.type as unknown as TransactionType` on create; capture new type when categoryId changes on update
- Add unit tests: INCOME/EXPENSE derivation on create, type update on category change, type unchanged when categoryId not updated
- Remove `type` from all e2e transaction request bodies
- Remove type selector from TransactionForm and related state/validation
- Update MSW handlers to derive type from mock category data