### PR TITLE
fix(ci-cd): force-recreate api/web containers on deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -189,9 +189,11 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           envs: GHCR_TOKEN,GITHUB_ACTOR,API_IMAGE,WEB_IMAGE,GRAFANA_ADMIN_PASSWORD
           script: |
+            set -e
             cd ${{ secrets.VPS_APP_DIR }}
             git pull origin main
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-            docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml pull api web
+            docker compose -f docker-compose.prod.yml up -d --force-recreate --no-deps api web
             docker logout ghcr.io
+            docker image prune -f


### PR DESCRIPTION
- Add set -e to fail fast on any deploy script error
- Pull only api/web images instead of all services
- Use --force-recreate --no-deps to ensure app containers are always updated
- Prune dangling images after deploy to avoid disk buildup