### PR TITLE
feat(web): add client-side error logging via Loki

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ This is a **Turborepo + npm workspaces** monorepo:
 
 **Error handling:** `ErrorBoundary` (`src/components/ErrorBoundary.tsx`) wraps the app in `layout.tsx`. It is implemented as a functional component (`ErrorBoundary`) that renders an inner class component (`ErrorBoundaryInner`) — this allows the outer wrapper to call `useTranslations` while the class component handles `componentDidCatch`.
 
+**Error logging:** `src/lib/errorLogger.ts` exports `logError(error, context?)`, which POSTs structured JSON to `POST /api/log-error` (Next.js API route). The route writes JSON to stdout; Promtail scrapes it into Loki automatically via Docker SD. `ErrorBoundary.componentDidCatch` calls `logError`. `src/app/global-error.tsx` handles root layout errors and also calls `logError`. In tests, mock `@/lib/errorLogger` in `setup.ts`.
+
 **UI:** shadcn/ui components in `src/components/ui/` (auto-generated, don't hand-edit). Feature components (`CategoryForm`, `TransactionForm`, `BudgetForm`, `BudgetDetails`, `ThemeToggle`, `LanguageToggle`) live directly in `src/components/`. Charts use `recharts` (PieChart, BarChart) in the dashboard page.
 
 **Register flow (multi-step):** After successful registration the page transitions to a preset categories step (same URL). The user selects/deselects 11 common categories and clicks "Get Started" (calls `POST /categories/batch` with localized names, then redirects to `/dashboard`) or "Skip" (redirects directly). Preset keys are defined as a `PRESETS` constant in `page.tsx`; localized names come from the `presetCategories.names` namespace.

--- a/apps/web/src/app/api/log-error/route.ts
+++ b/apps/web/src/app/api/log-error/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json();
+
+  process.stdout.write(
+    JSON.stringify({
+      level: 'error',
+      time: Date.now(),
+      context: 'ClientError',
+      msg: `Client error: ${body.message ?? 'unknown'}`,
+      ...body,
+    }) + '\n',
+  );
+
+  return NextResponse.json(null, { status: 200 });
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { logError } from '@/lib/errorLogger';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logError(error, { type: 'global-error' });
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong</h2>
+        <button onClick={reset}>Try again</button>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import React, { Component, ReactNode } from 'react';
 import Link from 'next/link';
 import { AlertTriangle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { logError } from '@/lib/errorLogger';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -41,6 +42,7 @@ class ErrorBoundaryInner extends Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
+    logError(error, { componentStack: errorInfo.componentStack });
   }
 
   handleRetry = (): void => {

--- a/apps/web/src/lib/errorLogger.ts
+++ b/apps/web/src/lib/errorLogger.ts
@@ -1,0 +1,24 @@
+interface ErrorContext {
+  componentStack?: string | null;
+  type?: 'error-boundary' | 'unhandled-rejection' | 'global-error';
+}
+
+export async function logError(error: Error, context?: ErrorContext): Promise<void> {
+  try {
+    await fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        componentStack: context?.componentStack ?? undefined,
+        type: context?.type ?? 'error-boundary',
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        userAgent: typeof window !== 'undefined' ? navigator.userAgent : undefined,
+      }),
+    });
+  } catch {
+    // fail silently — don't throw inside an error handler
+    console.error('Failed to report error:', error);
+  }
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -22,6 +22,11 @@ console.error = (...args: unknown[]) => {
   originalConsoleError(...args);
 };
 
+// Mock errorLogger to prevent fetch calls in tests
+vi.mock('@/lib/errorLogger', () => ({
+  logError: vi.fn(),
+}));
+
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   useRouter: () => ({


### PR DESCRIPTION
POSTs structured JSON to /api/log-error on unhandled errors; the route writes to stdout so Promtail scrapes it into Loki automatically via Docker SD. ErrorBoundary.componentDidCatch and global-error.tsx both call logError. errorLogger is mocked in test setup to prevent fetch calls during tests.