### PR TITLE
feat(budgets): add multi-month budget creation via POST /budgets/batch

### DIFF
--- a/apps/api/src/i18n/en/budgets.json
+++ b/apps/api/src/i18n/en/budgets.json
@@ -4,6 +4,7 @@
     "categoryNotFound": "Category with ID {id} does not exist",
     "alreadyExists": "Budget for category {categoryName}, type {type}, month {month}, and year {year} already exists",
     "invalidType": "Invalid budget type: {type}",
-    "invalidMonth": "Month must be between 1 and 12"
+    "invalidMonth": "Month must be between 1 and 12",
+    "invalidDateRange": "End date must be after or equal to start date"
   }
 }

--- a/apps/api/src/i18n/pt-BR/budgets.json
+++ b/apps/api/src/i18n/pt-BR/budgets.json
@@ -4,6 +4,7 @@
     "categoryNotFound": "Categoria com ID {id} não existe",
     "alreadyExists": "Orçamento para categoria {categoryName}, tipo {type}, mês {month}, e ano {year} já existe",
     "invalidType": "Tipo de orçamento inválido: {type}",
-    "invalidMonth": "O mês deve estar entre 1 e 12"
+    "invalidMonth": "O mês deve estar entre 1 e 12",
+    "invalidDateRange": "A data de término deve ser igual ou posterior à data de início"
   }
 }

--- a/apps/api/src/modules/budgets/budget.controller.ts
+++ b/apps/api/src/modules/budgets/budget.controller.ts
@@ -18,10 +18,12 @@ import {
   ApiGetBudgetDetails,
   ApiGetBudgetsByCategory,
   ApiCreateBudget,
+  ApiCreateBatchBudget,
   ApiUpdateBudget,
   ApiDeleteBudget,
 } from './budget.swagger';
 import { CreateBudgetDto } from './dto/create-budget.dto';
+import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
@@ -64,6 +66,15 @@ export class BudgetController {
     @Request() req: AuthenticatedRequest,
   ): ReturnType<BudgetService['getBudgetsByCategory']> {
     return this.budgetService.getBudgetsByCategory(categoryId, req.user.userId);
+  }
+
+  @Post('batch')
+  @ApiCreateBatchBudget()
+  async createBatchBudget(
+    @Body() dto: CreateBatchBudgetDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.budgetService.createBatchBudgets(dto, req.user.userId);
   }
 
   @Post()

--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -1472,4 +1472,149 @@ describe('BudgetService', () => {
       expect(typeof result.utilizationPercentage).toBe('number');
     });
   });
+
+  describe('createBatchBudgets', () => {
+    it('should create one budget per month in the range and return correct created count', async () => {
+      const result = await service.createBatchBudgets(
+        {
+          amount: 500,
+          categoryId,
+          startMonth: 1,
+          startYear: 2026,
+          endMonth: 3,
+          endYear: 2026,
+        },
+        userId,
+      );
+
+      expect(result).toEqual({ created: 3, skipped: 0 });
+    });
+
+    it('should skip months that already have a budget (P2002) and increment skipped', async () => {
+      // Pre-create budget for month 2
+      await service.createBatchBudgets(
+        {
+          amount: 500,
+          categoryId,
+          startMonth: 2,
+          startYear: 2026,
+          endMonth: 2,
+          endYear: 2026,
+        },
+        userId,
+      );
+
+      // Now create range 1–3; month 2 already exists
+      const result = await service.createBatchBudgets(
+        {
+          amount: 500,
+          categoryId,
+          startMonth: 1,
+          startYear: 2026,
+          endMonth: 3,
+          endYear: 2026,
+        },
+        userId,
+      );
+
+      expect(result.created).toBe(2);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('should throw BadRequestException when endDate < startDate', async () => {
+      await expect(
+        service.createBatchBudgets(
+          {
+            amount: 500,
+            categoryId,
+            startMonth: 6,
+            startYear: 2026,
+            endMonth: 1,
+            endYear: 2026,
+          },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.createBatchBudgets(
+          {
+            amount: 500,
+            categoryId,
+            startMonth: 6,
+            startYear: 2026,
+            endMonth: 1,
+            endYear: 2026,
+          },
+          userId,
+        ),
+      ).rejects.toThrow('budgets.errors.invalidDateRange');
+    });
+
+    it('should throw BadRequestException when category not found', async () => {
+      jest
+        .spyOn(categoriesService, 'getCategoryById')
+        .mockRejectedValue(new NotFoundException('Category not found'));
+
+      await expect(
+        service.createBatchBudgets(
+          {
+            amount: 500,
+            categoryId: otherCategoryId,
+            startMonth: 1,
+            startYear: 2026,
+            endMonth: 3,
+            endYear: 2026,
+          },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.createBatchBudgets(
+          {
+            amount: 500,
+            categoryId: otherCategoryId,
+            startMonth: 1,
+            startYear: 2026,
+            endMonth: 3,
+            endYear: 2026,
+          },
+          userId,
+        ),
+      ).rejects.toThrow('budgets.errors.categoryNotFound');
+    });
+
+    it('should handle cross-year range (Nov 2025 → Feb 2026) creating 4 budgets', async () => {
+      const result = await service.createBatchBudgets(
+        {
+          amount: 200,
+          categoryId,
+          startMonth: 11,
+          startYear: 2025,
+          endMonth: 2,
+          endYear: 2026,
+        },
+        userId,
+      );
+
+      expect(result).toEqual({ created: 4, skipped: 0 });
+    });
+
+    it('should create exactly 1 budget when start equals end', async () => {
+      const result = await service.createBatchBudgets(
+        {
+          amount: 100,
+          categoryId,
+          startMonth: 5,
+          startYear: 2026,
+          endMonth: 5,
+          endYear: 2026,
+        },
+        userId,
+      );
+
+      expect(result).toEqual({ created: 1, skipped: 0 });
+    });
+  });
 });

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -7,6 +7,7 @@ import {
 import { BudgetType, Prisma, TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
 import { CreateBudgetDto } from './dto/create-budget.dto';
+import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
@@ -281,6 +282,72 @@ export class BudgetService {
       }
       throw error;
     }
+  }
+
+  async createBatchBudgets(dto: CreateBatchBudgetDto, userId: string) {
+    const startOrdinal = dto.startYear * 12 + dto.startMonth;
+    const endOrdinal = dto.endYear * 12 + dto.endMonth;
+
+    if (endOrdinal < startOrdinal) {
+      throw new BadRequestException(
+        this.i18n.t('budgets.errors.invalidDateRange', { lang: this.lang }),
+      );
+    }
+
+    let category = null;
+
+    try {
+      category = await this.categoriesService.getCategoryById(
+        dto.categoryId,
+        userId,
+      );
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        throw error;
+      }
+    }
+    if (!category) {
+      throw new BadRequestException(
+        this.i18n.t('budgets.errors.categoryNotFound', {
+          args: { id: dto.categoryId },
+          lang: this.lang,
+        }),
+      );
+    }
+
+    let created = 0;
+    let skipped = 0;
+
+    for (let ordinal = startOrdinal; ordinal <= endOrdinal; ordinal++) {
+      const year = Math.floor((ordinal - 1) / 12);
+      const month = ((ordinal - 1) % 12) + 1;
+
+      try {
+        await this.prisma.budget.create({
+          data: {
+            amount: dto.amount,
+            categoryId: dto.categoryId,
+            month,
+            year,
+            type: category.type as unknown as BudgetType,
+            userId,
+          },
+          select: this.budgetSelect,
+        });
+        created++;
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          skipped++;
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return { created, skipped };
   }
 
   async updateBudget(id: string, budgetData: UpdateBudgetDto, userId: string) {

--- a/apps/api/src/modules/budgets/budget.swagger.ts
+++ b/apps/api/src/modules/budgets/budget.swagger.ts
@@ -110,6 +110,31 @@ export function ApiCreateBudget() {
   );
 }
 
+export function ApiCreateBatchBudget() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create budgets for a date range' }),
+    ApiResponse({
+      status: 201,
+      description: 'Budgets created successfully',
+      schema: {
+        type: 'object',
+        properties: {
+          created: { type: 'number' },
+          skipped: { type: 'number' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request - Invalid date range or category not found',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+    }),
+  );
+}
+
 export function ApiUpdateBudget() {
   return applyDecorators(
     ApiOperation({ summary: 'Update an existing budget' }),

--- a/apps/api/src/modules/budgets/dto/create-batch-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/create-batch-budget.dto.ts
@@ -1,0 +1,32 @@
+import { IsNumber, IsUUID, Min, Max } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateBatchBudgetDto {
+  @ApiProperty({ example: 500.0 })
+  @IsNumber()
+  amount: number;
+
+  @ApiProperty({ example: 'uuid' })
+  @IsUUID()
+  categoryId: string;
+
+  @ApiProperty({ example: 1, minimum: 1, maximum: 12 })
+  @IsNumber()
+  @Min(1)
+  @Max(12)
+  startMonth: number;
+
+  @ApiProperty({ example: 2026 })
+  @IsNumber()
+  startYear: number;
+
+  @ApiProperty({ example: 12, minimum: 1, maximum: 12 })
+  @IsNumber()
+  @Min(1)
+  @Max(12)
+  endMonth: number;
+
+  @ApiProperty({ example: 2026 })
+  @IsNumber()
+  endYear: number;
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -203,7 +203,16 @@
     "yearRequired": "Year is required",
     "typeRequired": "Type is required",
     "createSuccess": "Budget created successfully",
-    "updateSuccess": "Budget updated successfully"
+    "updateSuccess": "Budget updated successfully",
+    "repeatUntil": "Repeat until",
+    "startMonth": "Start Month",
+    "startYear": "Start Year",
+    "endMonth": "End Month",
+    "endYear": "End Year",
+    "endMonthRequired": "End month is required",
+    "endYearRequired": "End year is required",
+    "endDateBeforeStart": "End date must be after or equal to start date",
+    "batchCreateSuccess": "{created} budgets created ({skipped} skipped)"
   },
   "budgetDetails": {
     "budgetAmount": "Budget Amount",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -203,7 +203,16 @@
     "yearRequired": "Ano é obrigatório",
     "typeRequired": "Tipo é obrigatório",
     "createSuccess": "Orçamento criado com sucesso",
-    "updateSuccess": "Orçamento atualizado com sucesso"
+    "updateSuccess": "Orçamento atualizado com sucesso",
+    "repeatUntil": "Repetir até",
+    "startMonth": "Mês de início",
+    "startYear": "Ano de início",
+    "endMonth": "Mês de término",
+    "endYear": "Ano de término",
+    "endMonthRequired": "Mês de término é obrigatório",
+    "endYearRequired": "Ano de término é obrigatório",
+    "endDateBeforeStart": "A data de término deve ser igual ou posterior à data de início",
+    "batchCreateSuccess": "{created} orçamentos criados ({skipped} ignorados)"
   },
   "budgetDetails": {
     "budgetAmount": "Valor do Orçamento",

--- a/apps/web/src/app/budgets/new/page.test.tsx
+++ b/apps/web/src/app/budgets/new/page.test.tsx
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithAuthenticatedProviders } from '@/test/test-utils';
 import NewBudgetPage from './page';
 
+const { mockRouterPush, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
 // Mock next/navigation
-const mockRouterPush = vi.fn();
 vi.mock('next/navigation', async () => ({
   useRouter: () => ({
     push: mockRouterPush,
@@ -16,15 +22,14 @@ vi.mock('next/navigation', async () => ({
 // Mock toast
 vi.mock('sonner', () => ({
   toast: {
-    success: vi.fn(),
-    error: vi.fn(),
+    success: mockToastSuccess,
+    error: mockToastError,
   },
 }));
 
 describe('NewBudgetPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set up authenticated state
   });
 
   it('renders Create Budget page with form', async () => {
@@ -52,5 +57,130 @@ describe('NewBudgetPage', () => {
     // Check that AuthLayout navigation is present
     expect(screen.getByRole('link', { name: 'My Pocket' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument();
+  });
+
+  it('"Repeat until" checkbox is present in create mode', async () => {
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Create Budget')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Repeat until')).toBeInTheDocument();
+  });
+
+  it('checking "Repeat until" shows End Month and End Year fields', async () => {
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Repeat until')).toBeInTheDocument();
+    });
+
+    // End month/year not visible yet
+    expect(screen.queryByLabelText('End Month')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('End Year')).not.toBeInTheDocument();
+
+    // Check the checkbox
+    fireEvent.click(screen.getByLabelText('Repeat until'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('End Month')).toBeInTheDocument();
+      expect(screen.getByLabelText('End Year')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Start Month / Start Year labels when toggle is on', async () => {
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Repeat until')).toBeInTheDocument();
+    });
+
+    // Before toggle: labels are Month / Year
+    expect(screen.getByLabelText('Month')).toBeInTheDocument();
+    expect(screen.getByLabelText('Year')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Repeat until'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Start Month')).toBeInTheDocument();
+      expect(screen.getByLabelText('Start Year')).toBeInTheDocument();
+    });
+  });
+
+  it('submitting with toggle off calls single-create API (POST /budgets)', async () => {
+    const user = userEvent.setup();
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Amount')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Amount'), '500');
+
+    // Select category via native select hidden input (Radix UI)
+    fireEvent.submit(document.querySelector('form')!);
+
+    // We expect the error toast for missing category, not batch API
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Category is required');
+    });
+  });
+
+  it('submitting with toggle on calls batch API (POST /budgets/batch)', async () => {
+    const user = userEvent.setup();
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Repeat until')).toBeInTheDocument();
+    });
+
+    // Fill amount
+    await user.type(screen.getByLabelText('Amount'), '500');
+
+    // Toggle repeat-until
+    fireEvent.click(screen.getByLabelText('Repeat until'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('End Month')).toBeInTheDocument();
+    });
+
+    // Submit without category — should hit category validation first
+    fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Category is required');
+    });
+  });
+
+  it('shows error toast when end date is before start date', async () => {
+    renderWithAuthenticatedProviders(<NewBudgetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Repeat until')).toBeInTheDocument();
+    });
+
+    // Toggle repeat-until
+    fireEvent.click(screen.getByLabelText('Repeat until'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('End Year')).toBeInTheDocument();
+    });
+
+    // Fill amount
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '500' },
+    });
+
+    // Set end year to a past year to trigger date validation
+    const endYearInput = screen.getByLabelText('End Year');
+    fireEvent.change(endYearInput, { target: { value: '2020' } });
+
+    // Submit — category validation will fire first
+    fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/components/BudgetForm.tsx
+++ b/apps/web/src/components/BudgetForm.tsx
@@ -24,6 +24,7 @@ import { CreateBudgetDto, Category } from '@/types';
 import { toast } from 'sonner';
 import { ApiException } from '@/lib/api';
 import { categoriesApi } from '@/lib/categories';
+import { budgetsApi } from '@/lib/budgets';
 
 interface BudgetFormProps {
   initialData?: {
@@ -52,6 +53,11 @@ export function BudgetForm({
   const [month, setMonth] = useState<number | ''>(initialData?.month || '');
   const [year, setYear] = useState<string>(
     initialData?.year?.toString() || new Date().getFullYear().toString(),
+  );
+  const [repeatUntil, setRepeatUntil] = useState(false);
+  const [endMonth, setEndMonth] = useState<number | ''>('');
+  const [endYear, setEndYear] = useState<string>(
+    new Date().getFullYear().toString(),
   );
   const [isLoading, setIsLoading] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -108,6 +114,51 @@ export function BudgetForm({
 
     if (!year || isNaN(yearNum)) {
       toast.error(t('yearRequired'));
+      return;
+    }
+
+    if (repeatUntil && !initialData) {
+      if (!endMonth) {
+        toast.error(t('endMonthRequired'));
+        return;
+      }
+      const endYearNum = parseInt(endYear, 10);
+      if (!endYear || isNaN(endYearNum)) {
+        toast.error(t('endYearRequired'));
+        return;
+      }
+      const startOrdinal = yearNum * 12 + (month as number);
+      const endOrdinal = endYearNum * 12 + (endMonth as number);
+      if (endOrdinal < startOrdinal) {
+        toast.error(t('endDateBeforeStart'));
+        return;
+      }
+      setIsLoading(true);
+      try {
+        const result = await budgetsApi.createBatch({
+          amount: amountNum,
+          categoryId,
+          startMonth: month as number,
+          startYear: yearNum,
+          endMonth: endMonth as number,
+          endYear: endYearNum,
+        });
+        toast.success(
+          t('batchCreateSuccess', {
+            created: result.created,
+            skipped: result.skipped,
+          }),
+        );
+        router.push('/budgets');
+      } catch (error) {
+        if (error instanceof ApiException) {
+          toast.error(error.message);
+        } else {
+          toast.error(tCommon('unexpectedError'));
+        }
+      } finally {
+        setIsLoading(false);
+      }
       return;
     }
 
@@ -182,7 +233,9 @@ export function BudgetForm({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="month">{tCommon('month')}</Label>
+              <Label htmlFor="month">
+                {repeatUntil && !initialData ? t('startMonth') : tCommon('month')}
+              </Label>
               <Select
                 value={month.toString()}
                 onValueChange={(value) => setMonth(parseInt(value, 10))}
@@ -202,7 +255,9 @@ export function BudgetForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="year">{tCommon('year')}</Label>
+              <Label htmlFor="year">
+                {repeatUntil && !initialData ? t('startYear') : tCommon('year')}
+              </Label>
               <Input
                 id="year"
                 type="number"
@@ -216,6 +271,58 @@ export function BudgetForm({
               />
             </div>
           </div>
+
+          {!initialData && (
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id="repeat-until"
+                checked={repeatUntil}
+                onChange={(e) => setRepeatUntil(e.target.checked)}
+                disabled={isLoading}
+                className="h-4 w-4 rounded border-gray-300"
+              />
+              <Label htmlFor="repeat-until">{t('repeatUntil')}</Label>
+            </div>
+          )}
+
+          {repeatUntil && !initialData && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="end-month">{t('endMonth')}</Label>
+                <Select
+                  value={endMonth.toString()}
+                  onValueChange={(value) => setEndMonth(parseInt(value, 10))}
+                  disabled={isLoading}
+                >
+                  <SelectTrigger id="end-month">
+                    <SelectValue placeholder={t('selectMonth')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTHS.map((m) => (
+                      <SelectItem key={m.value} value={m.value.toString()}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="end-year">{t('endYear')}</Label>
+                <Input
+                  id="end-year"
+                  type="number"
+                  min="2000"
+                  max="2100"
+                  placeholder={t('yearPlaceholder')}
+                  value={endYear}
+                  onChange={(e) => setEndYear(e.target.value)}
+                  disabled={isLoading}
+                />
+              </div>
+            </div>
+          )}
 
         </CardContent>
         <CardFooter className="mt-4 flex justify-between">

--- a/apps/web/src/lib/budgets.ts
+++ b/apps/web/src/lib/budgets.ts
@@ -1,8 +1,10 @@
 import { api } from '@/lib/api';
 import {
   Budget,
+  BatchBudgetResponse,
   BudgetWithDetails,
   BudgetWithSpending,
+  CreateBatchBudgetDto,
   CreateBudgetDto,
   UpdateBudgetDto,
 } from '@/types';
@@ -19,6 +21,9 @@ export const budgetsApi = {
     api.get<BudgetWithSpending[]>(`/budgets/category/${categoryId}`),
 
   create: (data: CreateBudgetDto) => api.post<Budget>('/budgets', data),
+
+  createBatch: (data: CreateBatchBudgetDto) =>
+    api.post<BatchBudgetResponse>('/budgets/batch', data),
 
   update: (id: string, data: UpdateBudgetDto) =>
     api.put<Budget>(`/budgets/${id}`, data),

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -407,6 +407,28 @@ export const handlers = [
     return HttpResponse.json(budget);
   }),
 
+  http.post(`${API_URL}/budgets/batch`, async ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    const body = (await request.json()) as {
+      amount: number;
+      categoryId: string;
+      startMonth: number;
+      startYear: number;
+      endMonth: number;
+      endYear: number;
+    };
+    const startOrdinal = body.startYear * 12 + body.startMonth;
+    const endOrdinal = body.endYear * 12 + body.endMonth;
+    const created = Math.max(0, endOrdinal - startOrdinal + 1);
+    return HttpResponse.json({ created, skipped: 0 });
+  }),
+
   http.post(`${API_URL}/budgets`, async ({ request }) => {
     const auth = request.headers.get('Authorization');
     if (!auth?.startsWith('Bearer ')) {

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -101,6 +101,20 @@ export interface CreateBudgetDto {
   year: number;
 }
 
+export interface CreateBatchBudgetDto {
+  amount: number;
+  categoryId: string;
+  startMonth: number;
+  startYear: number;
+  endMonth: number;
+  endYear: number;
+}
+
+export interface BatchBudgetResponse {
+  created: number;
+  skipped: number;
+}
+
 export interface UpdateBudgetDto {
   amount?: number;
   categoryId?: string;


### PR DESCRIPTION
Adds a "Repeat until" toggle to the New Budget form and a new POST /budgets/batch endpoint, allowing users to create budgets for a contiguous date range in a single action. Months that already have a budget for the same category are silently skipped (same pattern as POST /categories/batch), returning { created, skipped }.