### PR TITLE
feat(admin): add admin dashboard and user management

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { SharedModule } from './modules/shared';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { UsersModule } from './modules/users/users.module';
 import { RecurringTransactionsModule } from './modules/recurring-transactions/recurring-transactions.module';
+import { AdminModule } from './modules/admin/admin.module';
 
 const envFileMap: Record<string, string> = {
   test: '.env.test',
@@ -82,6 +83,7 @@ const resolveEnvFilePath = () =>
     DashboardModule,
     UsersModule,
     RecurringTransactionsModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/i18n/en/admin.json
+++ b/apps/api/src/i18n/en/admin.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "cannotDeactivateSelf": "You cannot deactivate your own account",
+    "userNotFound": "User not found"
+  }
+}

--- a/apps/api/src/i18n/en/auth.json
+++ b/apps/api/src/i18n/en/auth.json
@@ -5,7 +5,8 @@
     "invalidRefreshToken": "Invalid or expired refresh token",
     "invalidOrExpiredResetToken": "Invalid or expired password reset token",
     "emailNotVerified": "Please verify your email address before logging in",
-    "invalidOrExpiredVerificationToken": "Invalid or expired verification token"
+    "invalidOrExpiredVerificationToken": "Invalid or expired verification token",
+    "accountInactive": "Your account has been deactivated. Please contact support."
   },
   "success": {
     "passwordResetEmailSent": "If an account with that email exists, a password reset link has been sent",

--- a/apps/api/src/i18n/pt-BR/admin.json
+++ b/apps/api/src/i18n/pt-BR/admin.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "cannotDeactivateSelf": "Você não pode desativar sua própria conta",
+    "userNotFound": "Usuário não encontrado"
+  }
+}

--- a/apps/api/src/i18n/pt-BR/auth.json
+++ b/apps/api/src/i18n/pt-BR/auth.json
@@ -5,7 +5,8 @@
     "invalidRefreshToken": "Token de atualização inválido ou expirado",
     "invalidOrExpiredResetToken": "Token de redefinição de senha inválido ou expirado",
     "emailNotVerified": "Por favor, verifique seu endereço de e-mail antes de fazer login",
-    "invalidOrExpiredVerificationToken": "Token de verificação inválido ou expirado"
+    "invalidOrExpiredVerificationToken": "Token de verificação inválido ou expirado",
+    "accountInactive": "Sua conta foi desativada. Por favor, entre em contato com o suporte."
   },
   "success": {
     "passwordResetEmailSent": "Se existir uma conta com esse e-mail, um link de redefinição de senha foi enviado",

--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AdminGuard } from './admin.guard';
+import { AdminService } from './admin.service';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import {
+  ApiAdminStats,
+  ApiAdminUsers,
+  ApiAdminUpdateUserStatus,
+} from './admin.swagger';
+
+@ApiTags('admin')
+@ApiBearerAuth()
+@UseGuards(AdminGuard)
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('stats')
+  @ApiAdminStats()
+  getStats() {
+    return this.adminService.getStats();
+  }
+
+  @Get('users')
+  @ApiAdminUsers()
+  getUsers() {
+    return this.adminService.getUsers();
+  }
+
+  @Patch('users/:id/status')
+  @ApiAdminUpdateUserStatus()
+  updateUserStatus(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+    @Body() dto: UpdateUserStatusDto,
+  ) {
+    return this.adminService.updateUserStatus(
+      req.user.userId,
+      id,
+      dto.isActive,
+    );
+  }
+}

--- a/apps/api/src/modules/admin/admin.guard.ts
+++ b/apps/api/src/modules/admin/admin.guard.ts
@@ -1,0 +1,22 @@
+import {
+  Injectable,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auths/jwt-auth.guard';
+
+@Injectable()
+export class AdminGuard extends JwtAuthGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user?: { isAdmin?: boolean } }>();
+    if (!request.user?.isAdmin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { SharedModule } from '../shared/shared.module';
+
+@Module({
+  imports: [SharedModule],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/apps/api/src/modules/admin/admin.service.spec.ts
+++ b/apps/api/src/modules/admin/admin.service.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
+import { AdminService } from './admin.service';
+import { PrismaService } from '../shared/prisma.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let prismaService: PrismaService;
+
+  const prismaMock = {
+    user: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  } as unknown as PrismaService;
+
+  const i18nServiceMock = {
+    t: jest.fn((key: string) => key),
+  };
+
+  const mockUsers = [
+    {
+      id: 'user-1',
+      name: 'Alice',
+      email: 'alice@example.com',
+      isActive: true,
+      emailVerified: true,
+      isAdmin: true,
+      createdAt: new Date('2024-01-01'),
+    },
+    {
+      id: 'user-2',
+      name: 'Bob',
+      email: 'bob@example.com',
+      isActive: false,
+      emailVerified: true,
+      isAdmin: false,
+      createdAt: new Date('2024-01-02'),
+    },
+    {
+      id: 'user-3',
+      name: 'Carol',
+      email: 'carol@example.com',
+      isActive: true,
+      emailVerified: false,
+      isAdmin: false,
+      createdAt: new Date('2024-01-03'),
+    },
+  ];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: PrismaService, useValue: prismaMock },
+        { provide: I18nService, useValue: i18nServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getStats', () => {
+    it('should return correct user counts', async () => {
+      (prismaService.user.count as jest.Mock)
+        .mockResolvedValueOnce(10)
+        .mockResolvedValueOnce(8)
+        .mockResolvedValueOnce(2);
+
+      const result = await service.getStats();
+
+      expect(result).toEqual({
+        totalUsers: 10,
+        activeUsers: 8,
+        inactiveUsers: 2,
+      });
+      expect(prismaService.user.count).toHaveBeenCalledTimes(3);
+      expect(prismaService.user.count).toHaveBeenCalledWith({
+        where: { isActive: true },
+      });
+      expect(prismaService.user.count).toHaveBeenCalledWith({
+        where: { isActive: false },
+      });
+    });
+  });
+
+  describe('getUsers', () => {
+    it('should return all users ordered by createdAt desc', async () => {
+      (prismaService.user.findMany as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await service.getUsers();
+
+      expect(result).toEqual(mockUsers);
+      expect(prismaService.user.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          isActive: true,
+          emailVerified: true,
+          isAdmin: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+  });
+
+  describe('updateUserStatus', () => {
+    it('should update user status successfully', async () => {
+      const adminId = 'admin-id';
+      const targetId = 'user-2';
+      const updatedUser = { ...mockUsers[1], isActive: true };
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(
+        mockUsers[1],
+      );
+      (prismaService.user.update as jest.Mock).mockResolvedValue(updatedUser);
+
+      const result = await service.updateUserStatus(adminId, targetId, true);
+
+      expect(result).toEqual(updatedUser);
+      expect(prismaService.user.update).toHaveBeenCalledWith({
+        where: { id: targetId },
+        data: { isActive: true },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          isActive: true,
+          emailVerified: true,
+          isAdmin: true,
+          createdAt: true,
+        },
+      });
+    });
+
+    it('should throw ForbiddenException when admin tries to deactivate self', async () => {
+      const adminId = 'user-1';
+
+      await expect(
+        service.updateUserStatus(adminId, adminId, false),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.updateUserStatus(adminId, adminId, false),
+      ).rejects.toThrow('admin.errors.cannotDeactivateSelf');
+    });
+
+    it('should throw NotFoundException when target user does not exist', async () => {
+      const adminId = 'admin-id';
+      const targetId = 'nonexistent-id';
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.updateUserStatus(adminId, targetId, false),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.updateUserStatus(adminId, targetId, false),
+      ).rejects.toThrow('admin.errors.userNotFound');
+    });
+  });
+});

--- a/apps/api/src/modules/admin/admin.service.ts
+++ b/apps/api/src/modules/admin/admin.service.ts
@@ -1,0 +1,77 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { I18nService, I18nContext } from 'nestjs-i18n';
+import { PrismaService } from '../shared/prisma.service';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly i18n: I18nService,
+  ) {}
+
+  private get lang(): string {
+    return I18nContext.current()?.lang ?? 'en';
+  }
+
+  async getStats(): Promise<{
+    totalUsers: number;
+    activeUsers: number;
+    inactiveUsers: number;
+  }> {
+    const [totalUsers, activeUsers, inactiveUsers] = await Promise.all([
+      this.prisma.user.count(),
+      this.prisma.user.count({ where: { isActive: true } }),
+      this.prisma.user.count({ where: { isActive: false } }),
+    ]);
+
+    return { totalUsers, activeUsers, inactiveUsers };
+  }
+
+  async getUsers() {
+    return this.prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        isActive: true,
+        emailVerified: true,
+        isAdmin: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async updateUserStatus(adminId: string, targetId: string, isActive: boolean) {
+    if (adminId === targetId) {
+      throw new ForbiddenException(
+        this.i18n.t('admin.errors.cannotDeactivateSelf', { lang: this.lang }),
+      );
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: targetId } });
+    if (!user) {
+      throw new NotFoundException(
+        this.i18n.t('admin.errors.userNotFound', { lang: this.lang }),
+      );
+    }
+
+    return this.prisma.user.update({
+      where: { id: targetId },
+      data: { isActive },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        isActive: true,
+        emailVerified: true,
+        isAdmin: true,
+        createdAt: true,
+      },
+    });
+  }
+}

--- a/apps/api/src/modules/admin/admin.swagger.ts
+++ b/apps/api/src/modules/admin/admin.swagger.ts
@@ -1,0 +1,43 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+
+export function ApiAdminStats() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get admin dashboard stats' }),
+    ApiResponse({
+      status: 200,
+      description: 'User statistics',
+    }),
+    ApiResponse({ status: 401, description: 'Unauthorized' }),
+    ApiResponse({ status: 403, description: 'Forbidden - Admin only' }),
+  );
+}
+
+export function ApiAdminUsers() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all users (admin)' }),
+    ApiResponse({
+      status: 200,
+      description: 'List of all users',
+    }),
+    ApiResponse({ status: 401, description: 'Unauthorized' }),
+    ApiResponse({ status: 403, description: 'Forbidden - Admin only' }),
+  );
+}
+
+export function ApiAdminUpdateUserStatus() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Activate or deactivate a user account' }),
+    ApiParam({ name: 'id', description: 'User ID', type: 'string' }),
+    ApiResponse({
+      status: 200,
+      description: 'User status updated',
+    }),
+    ApiResponse({ status: 401, description: 'Unauthorized' }),
+    ApiResponse({
+      status: 403,
+      description: 'Forbidden - Admin only or cannot deactivate self',
+    }),
+    ApiResponse({ status: 404, description: 'User not found' }),
+  );
+}

--- a/apps/api/src/modules/admin/dto/update-user-status.dto.ts
+++ b/apps/api/src/modules/admin/dto/update-user-status.dto.ts
@@ -1,0 +1,8 @@
+import { IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateUserStatusDto {
+  @ApiProperty({ description: 'Whether the user account is active' })
+  @IsBoolean()
+  isActive: boolean;
+}

--- a/apps/api/src/modules/auths/auths.service.spec.ts
+++ b/apps/api/src/modules/auths/auths.service.spec.ts
@@ -166,6 +166,8 @@ describe('AuthsService', () => {
       password: 'hashedPassword',
       refreshToken: null,
       emailVerified: true,
+      isActive: true,
+      isAdmin: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -185,6 +187,19 @@ describe('AuthsService', () => {
         access_token: 'access.token',
         refresh_token: 'refresh.token',
       });
+    });
+
+    it('should throw ForbiddenException when account is inactive', async () => {
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
+        ...mockUser,
+        isActive: false,
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await expect(service.login(loginDto)).rejects.toThrow(ForbiddenException);
+      await expect(service.login(loginDto)).rejects.toThrow(
+        'auth.errors.accountInactive',
+      );
     });
 
     it('should throw ForbiddenException when email is not verified', async () => {
@@ -332,11 +347,11 @@ describe('AuthsService', () => {
       });
       expect(jwtService.signAsync).toHaveBeenCalledTimes(2);
       expect(jwtService.signAsync).toHaveBeenCalledWith(
-        { userId, email },
+        { userId, email, isAdmin: false },
         { expiresIn: 900 },
       );
       expect(jwtService.signAsync).toHaveBeenCalledWith(
-        { userId, email },
+        { userId, email, isAdmin: false },
         { expiresIn: 604800 },
       );
     });
@@ -361,7 +376,7 @@ describe('AuthsService', () => {
       });
     });
 
-    it('should use payload with userId and email only', async () => {
+    it('should use payload with userId, email, and isAdmin', async () => {
       const userId = '456e4567-e89b-12d3-a456-426614174001';
       const email = 'another@example.com';
 
@@ -369,11 +384,11 @@ describe('AuthsService', () => {
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashedToken');
       (prismaService.user.update as jest.Mock).mockResolvedValue({});
 
-      await service.generateToken(userId, email);
+      await service.generateToken(userId, email, true);
 
       const firstCallPayload = jwtServiceMock.signAsync.mock.calls[0][0];
-      expect(Object.keys(firstCallPayload)).toHaveLength(2);
-      expect(firstCallPayload).toEqual({ userId, email });
+      expect(Object.keys(firstCallPayload)).toHaveLength(3);
+      expect(firstCallPayload).toEqual({ userId, email, isAdmin: true });
     });
   });
 });

--- a/apps/api/src/modules/auths/auths.service.ts
+++ b/apps/api/src/modules/auths/auths.service.ts
@@ -94,13 +94,19 @@ export class AuthsService {
       );
     }
 
+    if (!user.isActive) {
+      throw new ForbiddenException(
+        this.i18n.t('auth.errors.accountInactive', { lang: this.lang }),
+      );
+    }
+
     if (!user.emailVerified) {
       throw new ForbiddenException(
         this.i18n.t('auth.errors.emailNotVerified', { lang: this.lang }),
       );
     }
 
-    return this.generateToken(user.id, user.email);
+    return this.generateToken(user.id, user.email, user.isAdmin);
   }
 
   async refresh(
@@ -136,7 +142,7 @@ export class AuthsService {
       );
     }
 
-    return this.generateToken(user.id, user.email);
+    return this.generateToken(user.id, user.email, user.isAdmin);
   }
 
   async logout(userId: string): Promise<void> {
@@ -149,8 +155,9 @@ export class AuthsService {
   async generateToken(
     userId: string,
     email: string,
+    isAdmin: boolean = false,
   ): Promise<{ access_token: string; refresh_token: string }> {
-    const payload = { userId, email };
+    const payload = { userId, email, isAdmin };
 
     const accessExpiresIn = this.configService.get<number>(
       'jwt.expiresInSeconds',

--- a/apps/api/src/modules/auths/email-verification.service.ts
+++ b/apps/api/src/modules/auths/email-verification.service.ts
@@ -107,7 +107,7 @@ export class EmailVerificationService {
       }),
     ]);
 
-    return this.generateToken(user.id, user.email);
+    return this.generateToken(user.id, user.email, user.isAdmin);
   }
 
   async resendVerification(
@@ -132,8 +132,9 @@ export class EmailVerificationService {
   async generateToken(
     userId: string,
     email: string,
+    isAdmin: boolean = false,
   ): Promise<{ access_token: string; refresh_token: string }> {
-    const payload = { userId, email };
+    const payload = { userId, email, isAdmin };
 
     const accessExpiresIn = this.configService.get<number>(
       'jwt.expiresInSeconds',

--- a/apps/api/src/modules/auths/jwt.strategy.ts
+++ b/apps/api/src/modules/auths/jwt.strategy.ts
@@ -34,11 +34,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('User not found');
     }
 
+    if (!user.isActive) {
+      throw new UnauthorizedException('Account is deactivated');
+    }
+
     // Return user object that will be attached to request
     return {
       userId: user.id,
       email: user.email,
       name: user.name,
+      isAdmin: user.isAdmin,
     };
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -39,7 +39,8 @@
     "transactions": "Transactions",
     "recurringTransactions": "Recurring",
     "settings": "Settings",
-    "logout": "Logout"
+    "logout": "Logout",
+    "admin": "Admin"
   },
   "home": {
     "tagline": "Personal Finance Management",
@@ -347,6 +348,34 @@
     "loadingCategories": "Loading categories...",
     "failedToLoadCategories": "Failed to load categories",
     "endDateOptional": "End Date (optional)"
+  },
+  "admin": {
+    "title": "Admin Dashboard",
+    "backToAdmin": "Back to Admin",
+    "stats": {
+      "title": "User Statistics",
+      "totalUsers": "Total Users",
+      "activeUsers": "Active Users",
+      "inactiveUsers": "Inactive Users"
+    },
+    "userList": {
+      "title": "User Management",
+      "name": "Name",
+      "email": "Email",
+      "status": "Status",
+      "emailVerified": "Email Verified",
+      "joined": "Joined",
+      "actions": "Actions"
+    },
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "statusActive": "Active",
+    "statusInactive": "Inactive",
+    "deactivateSuccess": "User deactivated successfully",
+    "activateSuccess": "User activated successfully",
+    "accessDenied": "Access denied. Admin privileges required.",
+    "manageUsers": "Manage Users",
+    "failedToLoad": "Failed to load admin data"
   },
   "months": {
     "1": "January",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -39,7 +39,8 @@
     "transactions": "Transações",
     "recurringTransactions": "Recorrentes",
     "settings": "Configurações",
-    "logout": "Sair"
+    "logout": "Sair",
+    "admin": "Admin"
   },
   "home": {
     "tagline": "Gestão de Finanças Pessoais",
@@ -347,6 +348,34 @@
     "loadingCategories": "Carregando categorias...",
     "failedToLoadCategories": "Falha ao carregar categorias",
     "endDateOptional": "Data de Término (opcional)"
+  },
+  "admin": {
+    "title": "Painel Administrativo",
+    "backToAdmin": "Voltar ao Admin",
+    "stats": {
+      "title": "Estatísticas de Usuários",
+      "totalUsers": "Total de Usuários",
+      "activeUsers": "Usuários Ativos",
+      "inactiveUsers": "Usuários Inativos"
+    },
+    "userList": {
+      "title": "Gerenciamento de Usuários",
+      "name": "Nome",
+      "email": "E-mail",
+      "status": "Status",
+      "emailVerified": "E-mail Verificado",
+      "joined": "Cadastrado em",
+      "actions": "Ações"
+    },
+    "activate": "Ativar",
+    "deactivate": "Desativar",
+    "statusActive": "Ativo",
+    "statusInactive": "Inativo",
+    "deactivateSuccess": "Usuário desativado com sucesso",
+    "activateSuccess": "Usuário ativado com sucesso",
+    "accessDenied": "Acesso negado. Privilégios de administrador necessários.",
+    "manageUsers": "Gerenciar Usuários",
+    "failedToLoad": "Falha ao carregar dados administrativos"
   },
   "months": {
     "1": "Janeiro",

--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mocks/server';
+import { mockToken, mockAdminUser } from '@/test/mocks/handlers';
+import { render } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { AuthContext } from '@/contexts/AuthContext';
+import { setAccessToken } from '@/lib/api';
+import enMessages from '../../../messages/en.json';
+import AdminPage from './page';
+
+const API_URL = 'http://localhost:3001';
+
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', async () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+function renderWithAdminUser() {
+  setAccessToken(mockToken);
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AuthContext.Provider
+        value={{
+          user: mockAdminUser,
+          token: mockToken,
+          isAuthenticated: true,
+          isLoading: false,
+          login: vi.fn(),
+          register: vi.fn(),
+          loginWithTokens: vi.fn(),
+          logout: vi.fn(),
+          updateUser: vi.fn(),
+        }}
+      >
+        <AdminPage />
+      </AuthContext.Provider>
+    </NextIntlClientProvider>,
+  );
+}
+
+function renderWithRegularUser() {
+  setAccessToken(mockToken);
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AuthContext.Provider
+        value={{
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+            name: 'Test User',
+            isAdmin: false,
+          },
+          token: mockToken,
+          isAuthenticated: true,
+          isLoading: false,
+          login: vi.fn(),
+          register: vi.fn(),
+          loginWithTokens: vi.fn(),
+          logout: vi.fn(),
+          updateUser: vi.fn(),
+        }}
+      >
+        <AdminPage />
+      </AuthContext.Provider>
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('AdminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders stat cards with correct numbers', async () => {
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('User Statistics')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Total Users')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('Active Users')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('Inactive Users')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders Manage Users link', async () => {
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Manage Users')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects non-admin user to dashboard', async () => {
+    renderWithRegularUser();
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('shows error message when stats fetch fails', async () => {
+    server.use(
+      http.get(`${API_URL}/admin/stats`, () =>
+        HttpResponse.json(
+          { message: 'Forbidden', statusCode: 403 },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load admin data')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthLayout } from '@/components/layouts/AuthLayout';
+import { adminApi } from '@/lib/admin';
+import { AdminStats } from '@/types';
+
+export default function AdminPage() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const t = useTranslations('admin');
+  const tCommon = useTranslations('common');
+
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingStats, setLoadingStats] = useState(true);
+
+  useEffect(() => {
+    if (!isLoading && !user?.isAdmin) {
+      router.push('/dashboard');
+    }
+  }, [isLoading, user, router]);
+
+  useEffect(() => {
+    if (!isLoading && user?.isAdmin) {
+      adminApi
+        .getStats()
+        .then(setStats)
+        .catch(() => setError(t('failedToLoad')))
+        .finally(() => setLoadingStats(false));
+    }
+  }, [isLoading, user, t]);
+
+  if (isLoading || !user?.isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">{tCommon('loading')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <AuthLayout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold text-foreground">{t('title')}</h1>
+
+        {loadingStats && (
+          <p className="text-muted-foreground">{tCommon('loading')}</p>
+        )}
+        {error && <p className="text-destructive">{error}</p>}
+
+        {stats && (
+          <div>
+            <h2 className="text-xl font-semibold text-foreground mb-4">
+              {t('stats.title')}
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="rounded-lg border border-border bg-card p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  {t('stats.totalUsers')}
+                </p>
+                <p className="text-4xl font-bold text-foreground mt-2">
+                  {stats.totalUsers}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border bg-card p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  {t('stats.activeUsers')}
+                </p>
+                <p className="text-4xl font-bold text-foreground mt-2">
+                  {stats.activeUsers}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border bg-card p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  {t('stats.inactiveUsers')}
+                </p>
+                <p className="text-4xl font-bold text-foreground mt-2">
+                  {stats.inactiveUsers}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Link
+            href="/admin/users"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {t('manageUsers')}
+          </Link>
+        </div>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/app/admin/users/page.test.tsx
+++ b/apps/web/src/app/admin/users/page.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mocks/server';
+import {
+  mockToken,
+  mockAdminUser,
+  mockAdminUsers,
+} from '@/test/mocks/handlers';
+import { render } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { AuthContext } from '@/contexts/AuthContext';
+import { setAccessToken } from '@/lib/api';
+import enMessages from '../../../../messages/en.json';
+import AdminUsersPage from './page';
+
+const API_URL = 'http://localhost:3001';
+
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', async () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderWithAdminUser() {
+  setAccessToken(mockToken);
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AuthContext.Provider
+        value={{
+          user: mockAdminUser,
+          token: mockToken,
+          isAuthenticated: true,
+          isLoading: false,
+          login: vi.fn(),
+          register: vi.fn(),
+          loginWithTokens: vi.fn(),
+          logout: vi.fn(),
+          updateUser: vi.fn(),
+        }}
+      >
+        <AdminUsersPage />
+      </AuthContext.Provider>
+    </NextIntlClientProvider>,
+  );
+}
+
+function renderWithRegularUser() {
+  setAccessToken(mockToken);
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AuthContext.Provider
+        value={{
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+            name: 'Test User',
+            isAdmin: false,
+          },
+          token: mockToken,
+          isAuthenticated: true,
+          isLoading: false,
+          login: vi.fn(),
+          register: vi.fn(),
+          loginWithTokens: vi.fn(),
+          logout: vi.fn(),
+          updateUser: vi.fn(),
+        }}
+      >
+        <AdminUsersPage />
+      </AuthContext.Provider>
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('AdminUsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders user list table with user data', async () => {
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('User Management')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+  });
+
+  it('disables action button for own user row', async () => {
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // The first user (Test User) is the logged-in admin - their button should be disabled
+    const rows = screen.getAllByRole('row');
+    // Find the row for the admin user (test-user-id = mockAdminUsers[0])
+    const adminRow = rows.find((row) => row.textContent?.includes('Test User'));
+    expect(adminRow).toBeTruthy();
+    const button = adminRow!.querySelector('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('calls updateUserStatus and shows toast on deactivate', async () => {
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // Alice is active — find the enabled Deactivate button (own-user button is disabled)
+    const deactivateButtons = screen.getAllByRole('button', {
+      name: 'Deactivate',
+    });
+    const enabledDeactivate = deactivateButtons.find(
+      (btn) => !btn.hasAttribute('disabled'),
+    );
+    expect(enabledDeactivate).toBeTruthy();
+    await user.click(enabledDeactivate!);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+  });
+
+  it('calls updateUserStatus and shows toast on activate', async () => {
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+    renderWithAdminUser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
+    // Bob is inactive — click Activate
+    const activateButton = screen.getByRole('button', { name: 'Activate' });
+    await user.click(activateButton);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+  });
+
+  it('redirects non-admin user to dashboard', async () => {
+    renderWithRegularUser();
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+});

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthLayout } from '@/components/layouts/AuthLayout';
+import { adminApi } from '@/lib/admin';
+import { AdminUser } from '@/types';
+import { Button } from '@/components/ui/button';
+
+export default function AdminUsersPage() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const t = useTranslations('admin');
+  const tCommon = useTranslations('common');
+
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingUsers, setLoadingUsers] = useState(true);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !user?.isAdmin) {
+      router.push('/dashboard');
+    }
+  }, [isLoading, user, router]);
+
+  useEffect(() => {
+    if (!isLoading && user?.isAdmin) {
+      adminApi
+        .getUsers()
+        .then(setUsers)
+        .catch(() => setError(t('failedToLoad')))
+        .finally(() => setLoadingUsers(false));
+    }
+  }, [isLoading, user, t]);
+
+  async function handleStatusToggle(targetUser: AdminUser) {
+    setUpdatingId(targetUser.id);
+    try {
+      const updated = await adminApi.updateUserStatus(
+        targetUser.id,
+        !targetUser.isActive,
+      );
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      toast.success(
+        updated.isActive ? t('activateSuccess') : t('deactivateSuccess'),
+      );
+    } catch {
+      toast.error(tCommon('unexpectedError'));
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  if (isLoading || !user?.isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">{tCommon('loading')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <AuthLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold text-foreground">
+            {t('userList.title')}
+          </h1>
+          <Link
+            href="/admin"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            {t('backToAdmin')}
+          </Link>
+        </div>
+
+        {loadingUsers && (
+          <p className="text-muted-foreground">{tCommon('loading')}</p>
+        )}
+        {error && <p className="text-destructive">{error}</p>}
+
+        {!loadingUsers && !error && (
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.name')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.email')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.status')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.emailVerified')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.joined')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    {t('userList.actions')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {users.map((u) => (
+                  <tr key={u.id} className="bg-card">
+                    <td className="px-4 py-3 text-foreground">{u.name}</td>
+                    <td className="px-4 py-3 text-foreground">{u.email}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${
+                          u.isActive
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                        }`}
+                      >
+                        {u.isActive ? t('statusActive') : t('statusInactive')}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-foreground">
+                      {u.emailVerified ? '✓' : '✗'}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {new Date(u.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Button
+                        size="sm"
+                        variant={u.isActive ? 'destructive' : 'outline'}
+                        disabled={u.id === user.id || updatingId === u.id}
+                        onClick={() => handleStatusToggle(u)}
+                      >
+                        {u.isActive ? t('deactivate') : t('activate')}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/components/layouts/AuthLayout.tsx
+++ b/apps/web/src/components/layouts/AuthLayout.tsx
@@ -22,7 +22,7 @@ interface AuthLayoutProps {
 }
 
 export function AuthLayout({ children }: AuthLayoutProps) {
-  const { isAuthenticated, isLoading, logout } = useAuth();
+  const { isAuthenticated, isLoading, logout, user } = useAuth();
   const router = useRouter();
   const t = useTranslations('navigation');
   const tCommon = useTranslations('common');
@@ -80,6 +80,14 @@ export function AuthLayout({ children }: AuthLayoutProps) {
               >
                 {t('recurringTransactions')}
               </Link>
+              {user?.isAdmin && (
+                <Link
+                  href="/admin"
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {t('admin')}
+                </Link>
+              )}
             </nav>
           </div>
           <div className="flex items-center gap-2">

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -35,6 +35,7 @@ function decodeToken(token: string): User | null {
       id: decoded.userId,
       email: decoded.email,
       name: decoded.name || decoded.email.split('@')[0],
+      isAdmin: decoded.isAdmin ?? false,
     };
   } catch {
     return null;

--- a/apps/web/src/lib/admin.ts
+++ b/apps/web/src/lib/admin.ts
@@ -1,0 +1,9 @@
+import { api } from './api';
+import { AdminStats, AdminUser } from '@/types';
+
+export const adminApi = {
+  getStats: () => api.get<AdminStats>('/admin/stats'),
+  getUsers: () => api.get<AdminUser[]>('/admin/users'),
+  updateUserStatus: (id: string, isActive: boolean) =>
+    api.patch<AdminUser>(`/admin/users/${id}/status`, { isActive }),
+};

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -7,6 +7,14 @@ export const mockUser = {
   id: 'test-user-id',
   email: 'test@example.com',
   name: 'Test User',
+  isAdmin: false,
+};
+
+export const mockAdminUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+  name: 'Test User',
+  isAdmin: true,
 };
 
 export const mockCategories = [
@@ -193,6 +201,36 @@ export const mockRecurringTransactions = [
     endDate: undefined,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+export const mockAdminUsers = [
+  {
+    id: 'test-user-id',
+    name: 'Test User',
+    email: 'test@example.com',
+    isActive: true,
+    emailVerified: true,
+    isAdmin: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'user-2',
+    name: 'Alice',
+    email: 'alice@example.com',
+    isActive: true,
+    emailVerified: true,
+    isAdmin: false,
+    createdAt: '2024-01-02T00:00:00.000Z',
+  },
+  {
+    id: 'user-3',
+    name: 'Bob',
+    email: 'bob@example.com',
+    isActive: false,
+    emailVerified: true,
+    isAdmin: false,
+    createdAt: '2024-01-03T00:00:00.000Z',
   },
 ];
 
@@ -945,6 +983,55 @@ export const handlers = [
         );
       }
       return new HttpResponse(null, { status: 204 });
+    },
+  ),
+
+  // Admin endpoints
+  http.get(`${API_URL}/admin/stats`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json({
+      totalUsers: 10,
+      activeUsers: 8,
+      inactiveUsers: 2,
+    });
+  }),
+
+  http.get(`${API_URL}/admin/users`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json(mockAdminUsers);
+  }),
+
+  http.patch(
+    `${API_URL}/admin/users/:id/status`,
+    async ({ params, request }) => {
+      const auth = request.headers.get('Authorization');
+      if (!auth?.startsWith('Bearer ')) {
+        return HttpResponse.json(
+          { message: 'Unauthorized', statusCode: 401 },
+          { status: 401 },
+        );
+      }
+      const body = (await request.json()) as { isActive: boolean };
+      const user = mockAdminUsers.find((u) => u.id === params.id);
+      if (!user) {
+        return HttpResponse.json(
+          { message: 'User not found', statusCode: 404 },
+          { status: 404 },
+        );
+      }
+      return HttpResponse.json({ ...user, isActive: body.isActive });
     },
   ),
 ];

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -27,6 +27,23 @@ export interface User {
   id: string;
   email: string;
   name: string;
+  isAdmin: boolean;
+}
+
+export interface AdminStats {
+  totalUsers: number;
+  activeUsers: number;
+  inactiveUsers: number;
+}
+
+export interface AdminUser {
+  id: string;
+  name: string;
+  email: string;
+  isActive: boolean;
+  emailVerified: boolean;
+  isAdmin: boolean;
+  createdAt: string;
 }
 
 export interface UserProfile {

--- a/prisma/migrations/20260319001643_add_admin_and_isactive/migration.sql
+++ b/prisma/migrations/20260319001643_add_admin_and_isactive/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "isAdmin" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model User {
   password            String
   refreshToken        String?
   emailVerified       Boolean              @default(false)
+  isActive            Boolean              @default(true)
+  isAdmin             Boolean              @default(false)
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
   categories                Category[]


### PR DESCRIPTION
- Add isActive and isAdmin fields to User model with migration
- JwtStrategy blocks deactivated users; returns isAdmin in user object
- AuthsService: check inactive accounts on login; include isAdmin in JWT payload
- New AdminModule with guard, service, controller, swagger, and DTO
- AdminService: getStats(), getUsers(), updateUserStatus() with self-deactivation guard
- Frontend: AdminStats and AdminUser types, adminApi lib, admin pages (/admin, /admin/users)
- AuthLayout: Admin nav link visible only to admins
- i18n: add admin namespace and accountInactive error key (en + pt-BR)
- Tests: 243 API unit + 91 e2e + 296 web tests all passing