### PR TITLE
fix(security): harden credentials, body limits, bcrypt rounds, and i1…

### DIFF
--- a/apps/api/src/i18n/en/auth.json
+++ b/apps/api/src/i18n/en/auth.json
@@ -6,7 +6,10 @@
     "invalidOrExpiredResetToken": "Invalid or expired password reset token",
     "emailNotVerified": "Please verify your email address before logging in",
     "invalidOrExpiredVerificationToken": "Invalid or expired verification token",
-    "accountInactive": "Your account has been deactivated. Please contact support."
+    "accountInactive": "Your account has been deactivated. Please contact support.",
+    "userNotFound": "User not found",
+    "accountDeactivated": "Account is deactivated",
+    "adminAccessRequired": "Admin access required"
   },
   "success": {
     "passwordResetEmailSent": "If an account with that email exists, a password reset link has been sent",

--- a/apps/api/src/i18n/pt-BR/auth.json
+++ b/apps/api/src/i18n/pt-BR/auth.json
@@ -6,7 +6,10 @@
     "invalidOrExpiredResetToken": "Token de redefinição de senha inválido ou expirado",
     "emailNotVerified": "Por favor, verifique seu endereço de e-mail antes de fazer login",
     "invalidOrExpiredVerificationToken": "Token de verificação inválido ou expirado",
-    "accountInactive": "Sua conta foi desativada. Por favor, entre em contato com o suporte."
+    "accountInactive": "Sua conta foi desativada. Por favor, entre em contato com o suporte.",
+    "userNotFound": "Usuário não encontrado",
+    "accountDeactivated": "Conta desativada",
+    "adminAccessRequired": "Acesso de administrador necessário"
   },
   "success": {
     "passwordResetEmailSent": "Se existir uma conta com esse e-mail, um link de redefinição de senha foi enviado",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { I18nValidationPipe, I18nValidationExceptionFilter } from 'nestjs-i18n';
 import { Logger } from 'nestjs-pino';
 import helmet from 'helmet';
+import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
@@ -12,6 +13,8 @@ async function bootstrap() {
   app.useLogger(app.get(Logger));
 
   app.use(helmet());
+  app.use(json({ limit: '1mb' }));
+  app.use(urlencoded({ extended: true, limit: '1mb' }));
 
   const configService = app.get(ConfigService);
 

--- a/apps/api/src/modules/admin/admin.guard.ts
+++ b/apps/api/src/modules/admin/admin.guard.ts
@@ -3,10 +3,15 @@ import {
   ExecutionContext,
   ForbiddenException,
 } from '@nestjs/common';
+import { I18nService, I18nContext } from 'nestjs-i18n';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 
 @Injectable()
 export class AdminGuard extends JwtAuthGuard {
+  constructor(private readonly i18n: I18nService) {
+    super();
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     await super.canActivate(context);
 
@@ -14,7 +19,10 @@ export class AdminGuard extends JwtAuthGuard {
       .switchToHttp()
       .getRequest<{ user?: { isAdmin?: boolean } }>();
     if (!request.user?.isAdmin) {
-      throw new ForbiddenException('Admin access required');
+      const lang = I18nContext.current()?.lang ?? 'en';
+      throw new ForbiddenException(
+        this.i18n.t('auth.errors.adminAccessRequired', { lang }),
+      );
     }
 
     return true;

--- a/apps/api/src/modules/auths/auths.service.spec.ts
+++ b/apps/api/src/modules/auths/auths.service.spec.ts
@@ -114,7 +114,7 @@ describe('AuthsService', () => {
 
       await service.register(registerDto);
 
-      expect(bcrypt.hash).toHaveBeenCalledWith('Password1', 10);
+      expect(bcrypt.hash).toHaveBeenCalledWith('Password1', 12);
       expect(prismaService.user.create).toHaveBeenCalledWith({
         data: {
           name: 'John Doe',
@@ -369,7 +369,7 @@ describe('AuthsService', () => {
 
       await service.generateToken(userId, email);
 
-      expect(bcrypt.hash).toHaveBeenCalledWith(mockRefreshToken, 10);
+      expect(bcrypt.hash).toHaveBeenCalledWith(mockRefreshToken, 12);
       expect(prismaService.user.update).toHaveBeenCalledWith({
         where: { id: userId },
         data: { refreshToken: 'hashedValue' },

--- a/apps/api/src/modules/auths/auths.service.ts
+++ b/apps/api/src/modules/auths/auths.service.ts
@@ -31,8 +31,8 @@ export class AuthsService {
   async register(registerDto: RegisterDto): Promise<{ message: string }> {
     const { name, email, password } = registerDto;
 
-    // Hash password with bcrypt (10 salt rounds)
-    const hashedPassword = await bcrypt.hash(password, 10);
+    // Hash password with bcrypt (12 salt rounds)
+    const hashedPassword = await bcrypt.hash(password, 12);
 
     try {
       // Create user in database
@@ -175,7 +175,7 @@ export class AuthsService {
       expiresIn: refreshExpiresIn,
     });
 
-    const hashedRefreshToken = await bcrypt.hash(refresh_token, 10);
+    const hashedRefreshToken = await bcrypt.hash(refresh_token, 12);
     await this.prisma.user.update({
       where: { id: userId },
       data: { refreshToken: hashedRefreshToken },

--- a/apps/api/src/modules/auths/jwt.strategy.ts
+++ b/apps/api/src/modules/auths/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { I18nService, I18nContext } from 'nestjs-i18n';
 import { PrismaService } from '../shared/prisma.service';
 
 export interface JwtPayload {
@@ -14,6 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private configService: ConfigService,
     private prismaService: PrismaService,
+    private i18n: I18nService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -24,6 +26,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: JwtPayload) {
     const { userId } = payload;
+    const lang = I18nContext.current()?.lang ?? 'en';
 
     // Load user from database to ensure user still exists
     const user = await this.prismaService.user.findUnique({
@@ -31,11 +34,15 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
 
     if (!user) {
-      throw new UnauthorizedException('User not found');
+      throw new UnauthorizedException(
+        this.i18n.t('auth.errors.userNotFound', { lang }),
+      );
     }
 
     if (!user.isActive) {
-      throw new UnauthorizedException('Account is deactivated');
+      throw new UnauthorizedException(
+        this.i18n.t('auth.errors.accountDeactivated', { lang }),
+      );
     }
 
     // Return user object that will be attached to request

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -148,7 +148,7 @@ describe('UsersService', () => {
         'OldPassword1',
         mockUser.password,
       );
-      expect(bcrypt.hash).toHaveBeenCalledWith('NewPassword1', 10);
+      expect(bcrypt.hash).toHaveBeenCalledWith('NewPassword1', 12);
       expect(prismaService.user.update).toHaveBeenCalledWith({
         where: { id: userId },
         data: { password: 'new-hashed-password', refreshToken: null },

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -78,7 +78,7 @@ export class UsersService {
       );
     }
 
-    const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+    const hashedPassword = await bcrypt.hash(dto.newPassword, 12);
     await this.prisma.user.update({
       where: { id: userId },
       data: { password: hashedPassword, refreshToken: null },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -59,14 +59,18 @@ async function tryRefreshToken(): Promise<string | null> {
 
     if (!response.ok) {
       // Revoke the stale refresh token cookie
-      document.cookie = 'refresh_token=; path=/; max-age=0; SameSite=Strict';
+      const secureFlag =
+        window.location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `refresh_token=; path=/; max-age=0; SameSite=Strict${secureFlag}`;
       return null;
     }
 
     const data = await response.json();
     if (data.refresh_token) {
       const maxAge = 60 * 60 * 24 * 7;
-      document.cookie = `refresh_token=${data.refresh_token}; path=/; max-age=${maxAge}; SameSite=Strict`;
+      const secureFlag =
+        window.location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `refresh_token=${data.refresh_token}; path=/; max-age=${maxAge}; SameSite=Strict${secureFlag}`;
     }
     return data.access_token ?? null;
   } catch {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,8 @@ services:
     image: postgres:16-alpine
     container_name: my-pocket-postgres-dev
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: bd_my_pocket
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -25,8 +25,8 @@ services:
     image: postgres:16-alpine
     container_name: my-pocket-postgres-test
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: bd_my_pocket_test
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -47,7 +47,7 @@ services:
       target: development
     container_name: my-pocket-api-dev
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/bd_my_pocket
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bd_my_pocket}
       NODE_ENV: development
       JWT_SECRET: ${JWT_SECRET:-dev-secret-key-not-for-production}
       JWT_EXPIRATION: 3600

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,8 +3,8 @@ services:
     image: postgres:16-alpine
     container_name: my-pocket-postgres
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: bd_my_pocket
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -23,7 +23,7 @@ services:
     image: ${API_IMAGE}
     container_name: my-pocket-api
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/bd_my_pocket
+      DATABASE_URL: ${DATABASE_URL}
       NODE_ENV: production
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: 3600
@@ -92,7 +92,7 @@ services:
     ports:
       - '3500:3000'
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./config/grafana/datasources:/etc/grafana/provisioning/datasources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: postgres:16-alpine
     container_name: my-pocket-postgres-dev
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: bd_my_pocket
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -25,8 +25,8 @@ services:
     image: postgres:16-alpine
     container_name: my-pocket-postgres-test
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: bd_my_pocket_test
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -47,9 +47,9 @@ services:
       target: production
     container_name: my-pocket-api
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/bd_my_pocket
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bd_my_pocket}
       NODE_ENV: production
-      JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-key-change-this-in-production}
+      JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: 3600
       PORT: 3001
       RESEND_API_KEY: ${RESEND_API_KEY}


### PR DESCRIPTION
…8n errors

- Remove hardcoded postgres credentials from all docker-compose files; prod requires env vars with no fallback, dev keeps safe defaults
- Remove weak JWT_SECRET fallback from docker-compose.yml
- Remove Grafana admin password fallback from docker-compose.prod.yml
- Add 1mb request body size limit to prevent DoS via large payloads
- Increase bcrypt salt rounds from 10 to 12 in auths and users services
- Add Secure cookie flag for refresh_token when served over HTTPS
- Use i18n for error messages in JwtStrategy and AdminGuard
- Add userNotFound, accountDeactivated, adminAccessRequired i18n keys