### PR TITLE
fix(docker): remove POSTGRES_HOST_AUTH_METHOD trust from prod compose…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: bd_my_pocket
-      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - '5432:5432'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: bd_my_pocket
-      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - '5432:5432'
     volumes:


### PR DESCRIPTION
… files

trust auth bypasses password verification entirely, making the POSTGRES_PASSWORD credential hardening ineffective. Removing it from docker-compose.prod.yml and docker-compose.yml so PostgreSQL enforces password authentication in production environments.

docker-compose.dev.yml intentionally keeps trust for frictionless local development.