### PR TITLE
feat(dashboard): add budget totals to monthly summary cards

### DIFF
--- a/apps/api/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.spec.ts
@@ -61,6 +61,9 @@ describe('DashboardController', () => {
         totalIncome: 5000,
         totalExpense: 2000,
         balance: 3000,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       };
 
       jest
@@ -98,6 +101,9 @@ describe('DashboardController', () => {
         totalIncome: 1000,
         totalExpense: 500,
         balance: 500,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       };
 
       jest
@@ -123,6 +129,9 @@ describe('DashboardController', () => {
         totalIncome: 2000,
         totalExpense: 1000,
         balance: 1000,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       };
 
       jest
@@ -148,6 +157,9 @@ describe('DashboardController', () => {
         totalIncome: 0,
         totalExpense: 0,
         balance: 0,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       };
 
       jest
@@ -168,6 +180,9 @@ describe('DashboardController', () => {
         totalIncome: 0,
         totalExpense: 0,
         balance: 0,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       });
 
       await controller.getMonthlySummary(mockAuthenticatedRequest, 6, 2026);

--- a/apps/api/src/modules/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CategoryType, TransactionType } from '@prisma/client';
+import { BudgetType, CategoryType, TransactionType } from '@prisma/client';
 import { DashboardService } from './dashboard.service';
 import { PrismaService } from '../shared/prisma.service';
 
@@ -67,6 +67,7 @@ describe('DashboardService', () => {
       jest
         .spyOn(prismaService.transaction, 'findMany')
         .mockResolvedValue(formattedTransactions as any);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       const result = await service.getMonthlySummary(mockUserId, 2, 2026);
 
@@ -74,6 +75,9 @@ describe('DashboardService', () => {
         totalIncome: 1500,
         totalExpense: 500,
         balance: 1000,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       });
       expect(prismaService.transaction.findMany).toHaveBeenCalledWith({
         where: {
@@ -92,6 +96,7 @@ describe('DashboardService', () => {
 
     it('should return zero values when no transactions exist', async () => {
       jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       const result = await service.getMonthlySummary(mockUserId, 1, 2026);
 
@@ -99,6 +104,9 @@ describe('DashboardService', () => {
         totalIncome: 0,
         totalExpense: 0,
         balance: 0,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       });
     });
 
@@ -111,6 +119,7 @@ describe('DashboardService', () => {
       jest
         .spyOn(prismaService.transaction, 'findMany')
         .mockResolvedValue(transactions as any);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       const result = await service.getMonthlySummary(mockUserId, 3, 2026);
 
@@ -118,6 +127,9 @@ describe('DashboardService', () => {
         totalIncome: 1500,
         totalExpense: 0,
         balance: 1500,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       });
     });
 
@@ -130,6 +142,7 @@ describe('DashboardService', () => {
       jest
         .spyOn(prismaService.transaction, 'findMany')
         .mockResolvedValue(transactions as any);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       const result = await service.getMonthlySummary(mockUserId, 6, 2026);
 
@@ -137,11 +150,15 @@ describe('DashboardService', () => {
         totalIncome: 0,
         totalExpense: 400,
         balance: -400,
+        totalBudgetIncome: 0,
+        totalBudgetExpense: 0,
+        budgetBalance: 0,
       });
     });
 
     it('should filter transactions by userId', async () => {
       jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       await service.getMonthlySummary(mockUserId, 12, 2026);
 
@@ -152,6 +169,7 @@ describe('DashboardService', () => {
 
     it('should calculate correct date range for February', async () => {
       jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       await service.getMonthlySummary(mockUserId, 2, 2026);
 
@@ -174,11 +192,52 @@ describe('DashboardService', () => {
       jest
         .spyOn(prismaService.transaction, 'findMany')
         .mockResolvedValue(transactions as any);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
 
       const result = await service.getMonthlySummary(mockUserId, 5, 2026);
 
       expect(result.balance).toBe(result.totalIncome - result.totalExpense);
       expect(result.balance).toBe(3000);
+    });
+
+    it('should return correct budget totals from budget table', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest
+        .spyOn(prismaService.budget, 'findMany')
+        .mockResolvedValue([
+          { amount: 3000, type: BudgetType.INCOME } as any,
+          { amount: 500, type: BudgetType.INCOME } as any,
+          { amount: 1200, type: BudgetType.EXPENSE } as any,
+        ]);
+
+      const result = await service.getMonthlySummary(mockUserId, 4, 2026);
+
+      expect(result.totalBudgetIncome).toBe(3500);
+      expect(result.totalBudgetExpense).toBe(1200);
+      expect(result.budgetBalance).toBe(2300);
+    });
+
+    it('should return zero budget totals when no budgets exist', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
+
+      const result = await service.getMonthlySummary(mockUserId, 4, 2026);
+
+      expect(result.totalBudgetIncome).toBe(0);
+      expect(result.totalBudgetExpense).toBe(0);
+      expect(result.budgetBalance).toBe(0);
+    });
+
+    it('should query budgets scoped to userId, month and year', async () => {
+      jest.spyOn(prismaService.transaction, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.budget, 'findMany').mockResolvedValue([]);
+
+      await service.getMonthlySummary(mockUserId, 3, 2026);
+
+      expect(prismaService.budget.findMany).toHaveBeenCalledWith({
+        where: { userId: mockUserId, month: 3, year: 2026 },
+        select: { amount: true, type: true },
+      });
     });
   });
 

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CategoryType, TransactionType } from '@prisma/client';
+import { BudgetType, CategoryType, TransactionType } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import { BudgetVsActualDto } from './dto/budget-vs-actual.dto';
 import { MonthlySummaryDto } from './dto/monthly-summary.dto';
@@ -53,10 +53,27 @@ export class DashboardService {
 
     const balance = totalIncome - totalExpense;
 
+    const budgets = await this.prisma.budget.findMany({
+      where: { userId, month, year },
+      select: { amount: true, type: true },
+    });
+
+    let totalBudgetIncome = 0;
+    let totalBudgetExpense = 0;
+    budgets.forEach((b) => {
+      const amount = Number(b.amount);
+      if (b.type === BudgetType.INCOME) totalBudgetIncome += amount;
+      else totalBudgetExpense += amount;
+    });
+    const budgetBalance = totalBudgetIncome - totalBudgetExpense;
+
     return {
       totalIncome,
       totalExpense,
       balance,
+      totalBudgetIncome,
+      totalBudgetExpense,
+      budgetBalance,
     };
   }
 

--- a/apps/api/src/modules/dashboard/dto/monthly-summary.dto.ts
+++ b/apps/api/src/modules/dashboard/dto/monthly-summary.dto.ts
@@ -18,4 +18,22 @@ export class MonthlySummaryDto {
     example: 1500.0,
   })
   balance: number;
+
+  @ApiProperty({
+    description: 'Total budgeted income for the month',
+    example: 5000.0,
+  })
+  totalBudgetIncome: number;
+
+  @ApiProperty({
+    description: 'Total budgeted expenses for the month',
+    example: 3500.0,
+  })
+  totalBudgetExpense: number;
+
+  @ApiProperty({
+    description: 'Budget balance (budgetIncome - budgetExpense)',
+    example: 1500.0,
+  })
+  budgetBalance: number;
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -122,7 +122,8 @@
     "noExpenses": "No expenses for this period.",
     "date": "Date",
     "budget": "Budget",
-    "actual": "Actual"
+    "actual": "Actual",
+    "budgeted": "Budgeted"
   },
   "categories": {
     "title": "Categories",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -122,7 +122,8 @@
     "noExpenses": "Sem despesas para este período.",
     "date": "Data",
     "budget": "Orçamento",
-    "actual": "Real"
+    "actual": "Real",
+    "budgeted": "Orçado"
   },
   "categories": {
     "title": "Categorias",

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -180,6 +180,13 @@ export default function DashboardPage() {
             <p className="text-2xl font-bold text-green-600 dark:text-green-400">
               {formatCurrency(summary.totalIncome, locale)}
             </p>
+            {(summary.totalBudgetIncome > 0 ||
+              summary.totalBudgetExpense > 0) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('budgeted')}:{' '}
+                {formatCurrency(summary.totalBudgetIncome, locale)}
+              </p>
+            )}
           </div>
           <div className="bg-card rounded-lg shadow p-6">
             <p className="text-sm text-muted-foreground mb-1">
@@ -188,6 +195,13 @@ export default function DashboardPage() {
             <p className="text-2xl font-bold text-red-600 dark:text-red-400">
               {formatCurrency(summary.totalExpense, locale)}
             </p>
+            {(summary.totalBudgetIncome > 0 ||
+              summary.totalBudgetExpense > 0) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('budgeted')}:{' '}
+                {formatCurrency(summary.totalBudgetExpense, locale)}
+              </p>
+            )}
           </div>
           <div className="bg-card rounded-lg shadow p-6">
             <p className="text-sm text-muted-foreground mb-1">{t('balance')}</p>
@@ -196,6 +210,12 @@ export default function DashboardPage() {
             >
               {formatCurrency(summary.balance, locale)}
             </p>
+            {(summary.totalBudgetIncome > 0 ||
+              summary.totalBudgetExpense > 0) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('budgeted')}: {formatCurrency(summary.budgetBalance, locale)}
+              </p>
+            )}
           </div>
         </div>
       ) : null}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -266,6 +266,9 @@ export interface MonthlySummary {
   totalIncome: number;
   totalExpense: number;
   balance: number;
+  totalBudgetIncome: number;
+  totalBudgetExpense: number;
+  budgetBalance: number;
 }
 
 export interface BudgetVsActual {


### PR DESCRIPTION
Extend getMonthlySummary to query the Budget table and return totalBudgetIncome, totalBudgetExpense, and budgetBalance alongside actual transaction totals. Dashboard cards display a secondary "Budgeted" line when budgets exist for the period, hidden otherwise.