### PR TITLE
feat(web): add responsive layout for mobile screens

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -58,7 +58,7 @@ export default function AdminPage() {
             <h2 className="text-xl font-semibold text-foreground mb-4">
               {t('stats.title')}
             </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               <div className="rounded-lg border border-border bg-card p-6 text-center">
                 <p className="text-sm text-muted-foreground">
                   {t('stats.totalUsers')}

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -232,14 +232,17 @@ export default function BudgetsPage() {
         </Link>
       </div>
 
-      <div className="flex gap-4 mb-4">
+      <div className="flex flex-wrap gap-4 mb-4">
         <Select
           value={filterMonth === 'ALL' ? 'ALL' : String(filterMonth)}
           onValueChange={(value) =>
             setFilterMonth(value === 'ALL' ? 'ALL' : parseInt(value))
           }
         >
-          <SelectTrigger className="w-[150px]" data-testid="month-filter">
+          <SelectTrigger
+            className="w-full sm:w-[150px]"
+            data-testid="month-filter"
+          >
             <SelectValue placeholder={tCommon('filterByMonth')} />
           </SelectTrigger>
           <SelectContent>
@@ -258,7 +261,10 @@ export default function BudgetsPage() {
             setFilterYear(value === 'ALL' ? 'ALL' : parseInt(value))
           }
         >
-          <SelectTrigger className="w-[120px]" data-testid="year-filter">
+          <SelectTrigger
+            className="w-full sm:w-[120px]"
+            data-testid="year-filter"
+          >
             <SelectValue placeholder={tCommon('filterByYear')} />
           </SelectTrigger>
           <SelectContent>
@@ -275,7 +281,10 @@ export default function BudgetsPage() {
           value={filterType}
           onValueChange={(value) => setFilterType(value as FilterType)}
         >
-          <SelectTrigger className="w-[150px]" data-testid="type-filter">
+          <SelectTrigger
+            className="w-full sm:w-[150px]"
+            data-testid="type-filter"
+          >
             <SelectValue placeholder={tCommon('filterByType')} />
           </SelectTrigger>
           <SelectContent>
@@ -289,7 +298,10 @@ export default function BudgetsPage() {
           value={filterCategory}
           onValueChange={(value) => setFilterCategory(value as FilterCategory)}
         >
-          <SelectTrigger className="w-[180px]" data-testid="category-filter">
+          <SelectTrigger
+            className="w-full sm:w-[180px]"
+            data-testid="category-filter"
+          >
             <SelectValue placeholder={tCommon('filterByCategory')} />
           </SelectTrigger>
           <SelectContent>
@@ -321,105 +333,107 @@ export default function BudgetsPage() {
             {t('noMatch')}
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{tCommon('category')}</TableHead>
-                <TableHead>{tCommon('amount')}</TableHead>
-                {hasSpendingInfo && (
-                  <>
-                    <TableHead>{t('spentEarned')}</TableHead>
-                    <TableHead>{t('remaining')}</TableHead>
-                    <TableHead>{t('usage')}</TableHead>
-                  </>
-                )}
-                <TableHead>{t('period')}</TableHead>
-                <TableHead>{tCommon('type')}</TableHead>
-                <TableHead className="text-right">
-                  {tCommon('actions')}
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredBudgets.map((budget) => {
-                const progressValue = getProgressValue(budget);
-                return (
-                  <TableRow
-                    key={budget.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => router.push(`/budgets/${budget.id}`)}
-                  >
-                    <TableCell className="font-medium">
-                      {categoryMap[budget.categoryId] || tCommon('unknown')}
-                    </TableCell>
-                    <TableCell>
-                      {formatCurrencyFromString(budget.amount, locale)}
-                    </TableCell>
-                    {hasSpendingInfo && progressValue !== undefined && (
-                      <>
-                        <TableCell>
-                          {formatCurrencyFromString(progressValue, locale)}
-                        </TableCell>
-                        <TableCell
-                          className={
-                            parseFloat(budget.remaining || '0') < 0
-                              ? 'text-red-600 dark:text-red-400'
-                              : ''
-                          }
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{tCommon('category')}</TableHead>
+                  <TableHead>{tCommon('amount')}</TableHead>
+                  {hasSpendingInfo && (
+                    <>
+                      <TableHead>{t('spentEarned')}</TableHead>
+                      <TableHead>{t('remaining')}</TableHead>
+                      <TableHead>{t('usage')}</TableHead>
+                    </>
+                  )}
+                  <TableHead>{t('period')}</TableHead>
+                  <TableHead>{tCommon('type')}</TableHead>
+                  <TableHead className="text-right">
+                    {tCommon('actions')}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredBudgets.map((budget) => {
+                  const progressValue = getProgressValue(budget);
+                  return (
+                    <TableRow
+                      key={budget.id}
+                      className="cursor-pointer hover:bg-muted/50"
+                      onClick={() => router.push(`/budgets/${budget.id}`)}
+                    >
+                      <TableCell className="font-medium">
+                        {categoryMap[budget.categoryId] || tCommon('unknown')}
+                      </TableCell>
+                      <TableCell>
+                        {formatCurrencyFromString(budget.amount, locale)}
+                      </TableCell>
+                      {hasSpendingInfo && progressValue !== undefined && (
+                        <>
+                          <TableCell>
+                            {formatCurrencyFromString(progressValue, locale)}
+                          </TableCell>
+                          <TableCell
+                            className={
+                              parseFloat(budget.remaining || '0') < 0
+                                ? 'text-red-600 dark:text-red-400'
+                                : ''
+                            }
+                          >
+                            {formatCurrencyFromString(
+                              budget.remaining || '0',
+                              locale,
+                            )}
+                          </TableCell>
+                          <TableCell
+                            className={`font-medium ${getUtilizationColor(budget.utilizationPercentage, budget.type)}`}
+                          >
+                            {budget.utilizationPercentage?.toFixed(1)}%
+                          </TableCell>
+                        </>
+                      )}
+                      <TableCell className="text-muted-foreground">
+                        {tMonths(String(budget.month))} {budget.year}
+                      </TableCell>
+                      <TableCell>
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                            budget.type === 'INCOME'
+                              ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                              : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                          }`}
                         >
-                          {formatCurrencyFromString(
-                            budget.remaining || '0',
-                            locale,
-                          )}
-                        </TableCell>
-                        <TableCell
-                          className={`font-medium ${getUtilizationColor(budget.utilizationPercentage, budget.type)}`}
+                          {budget.type === 'INCOME'
+                            ? tCommon('income')
+                            : tCommon('expense')}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right space-x-2">
+                        <Link
+                          href={`/budgets/${budget.id}/edit`}
+                          onClick={(e) => e.stopPropagation()}
                         >
-                          {budget.utilizationPercentage?.toFixed(1)}%
-                        </TableCell>
-                      </>
-                    )}
-                    <TableCell className="text-muted-foreground">
-                      {tMonths(String(budget.month))} {budget.year}
-                    </TableCell>
-                    <TableCell>
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          budget.type === 'INCOME'
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                        }`}
-                      >
-                        {budget.type === 'INCOME'
-                          ? tCommon('income')
-                          : tCommon('expense')}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right space-x-2">
-                      <Link
-                        href={`/budgets/${budget.id}/edit`}
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Button variant="outline" size="sm">
-                          {tCommon('edit')}
+                          <Button variant="outline" size="sm">
+                            {tCommon('edit')}
+                          </Button>
+                        </Link>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteBudget(budget);
+                          }}
+                        >
+                          {tCommon('delete')}
                         </Button>
-                      </Link>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setDeleteBudget(budget);
-                        }}
-                      >
-                        {tCommon('delete')}
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </div>
 

--- a/apps/web/src/app/categories/page.tsx
+++ b/apps/web/src/app/categories/page.tsx
@@ -116,7 +116,7 @@ export default function CategoriesPage() {
         </Link>
       </div>
 
-      <div className="flex gap-4 mb-4">
+      <div className="flex flex-wrap gap-4 mb-4">
         <Input
           placeholder={t('searchPlaceholder')}
           value={searchQuery}
@@ -154,55 +154,59 @@ export default function CategoriesPage() {
             {t('noMatch')}
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{tCommon('name')}</TableHead>
-                <TableHead>{tCommon('type')}</TableHead>
-                <TableHead>{t('created')}</TableHead>
-                <TableHead className="text-right">
-                  {tCommon('actions')}
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredCategories.map((category) => (
-                <TableRow key={category.id}>
-                  <TableCell className="font-medium">{category.name}</TableCell>
-                  <TableCell>
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        category.type === 'INCOME'
-                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                      }`}
-                    >
-                      {category.type === 'INCOME'
-                        ? tCommon('income')
-                        : tCommon('expense')}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {new Date(category.createdAt).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell className="text-right space-x-2">
-                    <Link href={`/categories/${category.id}/edit`}>
-                      <Button variant="outline" size="sm">
-                        {tCommon('edit')}
-                      </Button>
-                    </Link>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => setDeleteCategory(category)}
-                    >
-                      {tCommon('delete')}
-                    </Button>
-                  </TableCell>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{tCommon('name')}</TableHead>
+                  <TableHead>{tCommon('type')}</TableHead>
+                  <TableHead>{t('created')}</TableHead>
+                  <TableHead className="text-right">
+                    {tCommon('actions')}
+                  </TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {filteredCategories.map((category) => (
+                  <TableRow key={category.id}>
+                    <TableCell className="font-medium">
+                      {category.name}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          category.type === 'INCOME'
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                        }`}
+                      >
+                        {category.type === 'INCOME'
+                          ? tCommon('income')
+                          : tCommon('expense')}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {new Date(category.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Link href={`/categories/${category.id}/edit`}>
+                        <Button variant="outline" size="sm">
+                          {tCommon('edit')}
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setDeleteCategory(category)}
+                      >
+                        {tCommon('delete')}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </div>
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -156,7 +156,7 @@ export default function DashboardPage() {
 
       {/* Summary Cards */}
       {isLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
           {[0, 1, 2].map((i) => (
             <div
               key={i}
@@ -172,7 +172,7 @@ export default function DashboardPage() {
           {t('failedToLoad')}
         </div>
       ) : summary ? (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
           <div className="bg-card rounded-lg shadow p-6">
             <p className="text-sm text-muted-foreground mb-1">
               {t('totalIncome')}
@@ -339,42 +339,44 @@ export default function DashboardPage() {
             {t('noExpenses')}
           </div>
         ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/50">
-                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
-                  {t('date')}
-                </th>
-                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
-                  {tCommon('category')}
-                </th>
-                <th className="px-6 py-3 text-left font-medium text-muted-foreground">
-                  {tCommon('description')}
-                </th>
-                <th className="px-6 py-3 text-right font-medium text-muted-foreground">
-                  {tCommon('amount')}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {topExpenses.map((expense) => (
-                <tr key={expense.id} className="border-b last:border-0">
-                  <td className="px-6 py-4 text-muted-foreground">
-                    {formatDate(expense.date, locale)}
-                  </td>
-                  <td className="px-6 py-4 font-medium">
-                    {expense.category.name}
-                  </td>
-                  <td className="px-6 py-4 text-muted-foreground">
-                    {expense.description ?? '—'}
-                  </td>
-                  <td className="px-6 py-4 text-right font-medium text-red-600 dark:text-red-400">
-                    {formatCurrency(expense.amount, locale)}
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-6 py-3 text-left font-medium text-muted-foreground">
+                    {t('date')}
+                  </th>
+                  <th className="px-6 py-3 text-left font-medium text-muted-foreground">
+                    {tCommon('category')}
+                  </th>
+                  <th className="px-6 py-3 text-left font-medium text-muted-foreground">
+                    {tCommon('description')}
+                  </th>
+                  <th className="px-6 py-3 text-right font-medium text-muted-foreground">
+                    {tCommon('amount')}
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {topExpenses.map((expense) => (
+                  <tr key={expense.id} className="border-b last:border-0">
+                    <td className="px-6 py-4 text-muted-foreground">
+                      {formatDate(expense.date, locale)}
+                    </td>
+                    <td className="px-6 py-4 font-medium">
+                      {expense.category.name}
+                    </td>
+                    <td className="px-6 py-4 text-muted-foreground">
+                      {expense.description ?? '—'}
+                    </td>
+                    <td className="px-6 py-4 text-right font-medium text-red-600 dark:text-red-400">
+                      {formatCurrency(expense.amount, locale)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </AuthLayout>

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -244,67 +244,70 @@ export default function TransactionsPage() {
             {t('noMatch')}
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{tCommon('date')}</TableHead>
-                <TableHead>{tCommon('description')}</TableHead>
-                <TableHead>{tCommon('category')}</TableHead>
-                <TableHead>{tCommon('type')}</TableHead>
-                <TableHead className="text-right">
-                  {tCommon('amount')}
-                </TableHead>
-                <TableHead className="text-right">
-                  {tCommon('actions')}
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredTransactions.map((transaction) => (
-                <TableRow key={transaction.id}>
-                  <TableCell className="text-muted-foreground">
-                    {formatDateUTC(transaction.date, locale)}
-                  </TableCell>
-                  <TableCell className="font-medium">
-                    {transaction.description || '-'}
-                  </TableCell>
-                  <TableCell>
-                    {categoryMap[transaction.categoryId] || tCommon('unknown')}
-                  </TableCell>
-                  <TableCell>
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        transaction.type === 'INCOME'
-                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                      }`}
-                    >
-                      {transaction.type === 'INCOME'
-                        ? tCommon('income')
-                        : tCommon('expense')}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {formatCurrencyFromString(transaction.amount, locale)}
-                  </TableCell>
-                  <TableCell className="text-right space-x-2">
-                    <Link href={`/transactions/${transaction.id}/edit`}>
-                      <Button variant="outline" size="sm">
-                        {tCommon('edit')}
-                      </Button>
-                    </Link>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => setDeleteTransaction(transaction)}
-                    >
-                      {tCommon('delete')}
-                    </Button>
-                  </TableCell>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{tCommon('date')}</TableHead>
+                  <TableHead>{tCommon('description')}</TableHead>
+                  <TableHead>{tCommon('category')}</TableHead>
+                  <TableHead>{tCommon('type')}</TableHead>
+                  <TableHead className="text-right">
+                    {tCommon('amount')}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {tCommon('actions')}
+                  </TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {filteredTransactions.map((transaction) => (
+                  <TableRow key={transaction.id}>
+                    <TableCell className="text-muted-foreground">
+                      {formatDateUTC(transaction.date, locale)}
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {transaction.description || '-'}
+                    </TableCell>
+                    <TableCell>
+                      {categoryMap[transaction.categoryId] ||
+                        tCommon('unknown')}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          transaction.type === 'INCOME'
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                        }`}
+                      >
+                        {transaction.type === 'INCOME'
+                          ? tCommon('income')
+                          : tCommon('expense')}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrencyFromString(transaction.amount, locale)}
+                    </TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Link href={`/transactions/${transaction.id}/edit`}>
+                        <Button variant="outline" size="sm">
+                          {tCommon('edit')}
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setDeleteTransaction(transaction)}
+                      >
+                        {tCommon('delete')}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/BudgetForm.tsx
+++ b/apps/web/src/components/BudgetForm.tsx
@@ -241,7 +241,7 @@ export function BudgetForm({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="month">
                 {repeatUntil && !initialData
@@ -299,7 +299,7 @@ export function BudgetForm({
           )}
 
           {repeatUntil && !initialData && (
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="end-month">{t('endMonth')}</Label>
                 <Select
@@ -336,7 +336,7 @@ export function BudgetForm({
             </div>
           )}
         </CardContent>
-        <CardFooter className="mt-4 flex justify-between">
+        <CardFooter className="mt-4 flex flex-col-reverse sm:flex-row sm:justify-between gap-3 sm:gap-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/web/src/components/CategoryForm.tsx
+++ b/apps/web/src/components/CategoryForm.tsx
@@ -116,7 +116,7 @@ export function CategoryForm({
             </Select>
           </div>
         </CardContent>
-        <CardFooter className="mt-4 flex justify-between">
+        <CardFooter className="mt-4 flex flex-col-reverse sm:flex-row sm:justify-between gap-3 sm:gap-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/web/src/components/TransactionForm.tsx
+++ b/apps/web/src/components/TransactionForm.tsx
@@ -201,7 +201,7 @@ export function TransactionForm({
             />
           </div>
         </CardContent>
-        <CardFooter className="mt-4 flex justify-between">
+        <CardFooter className="mt-4 flex flex-col-reverse sm:flex-row sm:justify-between gap-3 sm:gap-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/web/src/components/layouts/AuthLayout.tsx
+++ b/apps/web/src/components/layouts/AuthLayout.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, ReactNode } from 'react';
+import { useEffect, useState, ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { UserCircle } from 'lucide-react';
+import { UserCircle, Menu, X } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import {
@@ -26,6 +26,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
   const router = useRouter();
   const t = useTranslations('navigation');
   const tCommon = useTranslations('common');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -49,7 +50,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
             <Link href="/dashboard">
               <h1 className="text-2xl font-bold text-foreground">My Pocket</h1>
             </Link>
-            <nav className="flex items-center gap-4">
+            <nav className="hidden md:flex items-center gap-4">
               <Link
                 href="/dashboard"
                 className="text-sm font-medium text-muted-foreground hover:text-foreground"
@@ -91,6 +92,17 @@ export function AuthLayout({ children }: AuthLayoutProps) {
             </nav>
           </div>
           <div className="flex items-center gap-2">
+            <button
+              className="md:hidden p-2 text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen((o) => !o)}
+              aria-label="Toggle menu"
+            >
+              {mobileMenuOpen ? (
+                <X className="h-5 w-5" />
+              ) : (
+                <Menu className="h-5 w-5" />
+              )}
+            </button>
             <LanguageToggle />
             <ThemeToggle />
             <DropdownMenu>
@@ -112,6 +124,56 @@ export function AuthLayout({ children }: AuthLayoutProps) {
           </div>
         </div>
       </header>
+      {mobileMenuOpen && (
+        <div className="md:hidden bg-card border-b border-border">
+          <nav className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-3">
+            <Link
+              href="/dashboard"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t('dashboard')}
+            </Link>
+            <Link
+              href="/categories"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t('categories')}
+            </Link>
+            <Link
+              href="/budgets"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t('budgets')}
+            </Link>
+            <Link
+              href="/transactions"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t('transactions')}
+            </Link>
+            <Link
+              href="/recurring-transactions"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t('recurringTransactions')}
+            </Link>
+            {user?.isAdmin && (
+              <Link
+                href="/admin"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                {t('admin')}
+              </Link>
+            )}
+          </nav>
+        </div>
+      )}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {children}
       </main>


### PR DESCRIPTION
- AuthLayout: hamburger menu toggle (Menu/X) for mobile, desktop nav hidden on small screens, mobile dropdown nav with all links
- Dashboard, admin: fix summary cards grid to sm:grid-cols-2 lg:grid-cols-3 for better tablet display
- Budgets, categories, transactions, dashboard: wrap tables in overflow-x-auto for horizontal scroll on small screens
- Budgets: make filter selects full-width on mobile (w-full sm:w-[...])
- BudgetForm: stack month/year grids vertically on mobile (grid-cols-1 sm:grid-cols-2)
- CategoryForm, TransactionForm, BudgetForm: stack CardFooter buttons vertically on mobile (flex-col-reverse sm:flex-row)