### PR TITLE
Feat/pagination budgets transactions

### DIFF
--- a/apps/api/src/modules/budgets/budget.controller.ts
+++ b/apps/api/src/modules/budgets/budget.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   Put,
   ParseUUIDPipe,
+  Query,
   UseGuards,
   Request,
 } from '@nestjs/common';
@@ -25,6 +26,7 @@ import {
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
+import { GetBudgetsQueryDto } from './dto/get-budgets-query.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
@@ -37,8 +39,11 @@ export class BudgetController {
 
   @Get()
   @ApiGetAllBudgets()
-  async getAllBudgets(@Request() req: AuthenticatedRequest) {
-    return this.budgetService.getAllBudgets(req.user.userId);
+  async getAllBudgets(
+    @Request() req: AuthenticatedRequest,
+    @Query() query: GetBudgetsQueryDto,
+  ) {
+    return this.budgetService.getAllBudgets(req.user.userId, query);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/budgets/budget.controller.ts
+++ b/apps/api/src/modules/budgets/budget.controller.ts
@@ -39,10 +39,10 @@ export class BudgetController {
 
   @Get()
   @ApiGetAllBudgets()
-  async getAllBudgets(
+  getAllBudgets(
     @Request() req: AuthenticatedRequest,
     @Query() query: GetBudgetsQueryDto,
-  ) {
+  ): ReturnType<BudgetService['getAllBudgets']> {
     return this.budgetService.getAllBudgets(req.user.userId, query);
   }
 

--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -93,6 +93,20 @@ const createPrismaMock = () => {
           })
           .map(({ userId: _userId, ...rest }) => rest);
       }),
+      count: jest.fn(({ where } = {}) => {
+        if (!where) {
+          return budgets.length;
+        }
+        return budgets.filter((budget) => {
+          if (where.userId && budget.userId !== where.userId) {
+            return false;
+          }
+          if (where.categoryId && budget.categoryId !== where.categoryId) {
+            return false;
+          }
+          return true;
+        }).length;
+      }),
       findUnique: jest.fn(({ where: { id } }) => {
         const budget = budgets.find((budget) => budget.id === id);
         if (!budget) {
@@ -395,7 +409,7 @@ describe('BudgetService', () => {
       const result2 = await service.createBudget(createDto2, userId);
 
       expect(result1.id).not.toBe(result2.id);
-      expect(await service.getAllBudgets(userId)).toHaveLength(2);
+      expect((await service.getAllBudgets(userId)).data).toHaveLength(2);
     });
   });
 
@@ -415,7 +429,7 @@ describe('BudgetService', () => {
         amount: 700,
       };
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.updateBudget(budget.id, updateDto, userId);
 
       expect(result).toEqual({
@@ -443,7 +457,7 @@ describe('BudgetService', () => {
         month: 13,
       };
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
 
       await expect(
         service.updateBudget(budget.id, updateDto, userId),
@@ -466,7 +480,7 @@ describe('BudgetService', () => {
         categoryId: otherCategoryId,
       };
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
 
       await expect(
         service.updateBudget(budget.id, updateDto, userId),
@@ -483,7 +497,7 @@ describe('BudgetService', () => {
         year: 2026,
       };
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.updateBudget(budget.id, updateDto, userId);
 
       expect(result).toEqual({
@@ -520,8 +534,8 @@ describe('BudgetService', () => {
         month: 1,
       };
 
-      const budgets = await service.getAllBudgets(userId);
-      const secondBudget = budgets.find(
+      const { data: budgetsData } = await service.getAllBudgets(userId);
+      const secondBudget = budgetsData.find(
         (budget) => budget.categoryId === otherCategoryId,
       );
 
@@ -589,7 +603,7 @@ describe('BudgetService', () => {
     });
 
     it('should calculate spent amount for budget', async () => {
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const spent = await service.getSpentAmount(budget.id, userId);
 
       expect(spent).toBe(250);
@@ -603,7 +617,7 @@ describe('BudgetService', () => {
 
     it('should return 0 when no transactions match', async () => {
       prismaMock.__setTransactions([]);
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const spent = await service.getSpentAmount(budget.id, userId);
 
       expect(spent).toBe(0);
@@ -653,7 +667,7 @@ describe('BudgetService', () => {
     });
 
     it('should calculate remaining budget', async () => {
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const remaining = await service.getRemainingBudget(budget.id, userId);
 
       expect(remaining).toBe('300.00');
@@ -672,7 +686,7 @@ describe('BudgetService', () => {
         },
       ]);
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const remaining = await service.getRemainingBudget(budget.id, userId);
 
       expect(remaining).toBe('-100.00');
@@ -709,7 +723,7 @@ describe('BudgetService', () => {
         },
       ]);
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetWithSpending(budget.id, userId);
 
       if (!result) {
@@ -764,7 +778,7 @@ describe('BudgetService', () => {
         },
       ]);
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetWithSpending(budget.id, userId);
 
       if (!result) {
@@ -914,7 +928,7 @@ describe('BudgetService', () => {
     });
 
     it('should return budget with category', async () => {
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetWithCategory(budget.id, userId);
 
       expect(result).toEqual({
@@ -948,7 +962,7 @@ describe('BudgetService', () => {
           new NotFoundException(`Category with ID ${categoryId} not found`),
         );
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetWithCategory(budget.id, userId);
 
       expect(result!.category).toBeNull();
@@ -988,7 +1002,7 @@ describe('BudgetService', () => {
     });
 
     it('should return budget with category, transactions, and calculations', async () => {
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetsWithTransactions(
         budget.id,
         userId,
@@ -1054,7 +1068,7 @@ describe('BudgetService', () => {
         },
       ]);
 
-      const [budget] = await service.getAllBudgets(userId);
+      const [budget] = (await service.getAllBudgets(userId)).data;
       const result = await service.getBudgetsWithTransactions(
         budget.id,
         userId,
@@ -1189,8 +1203,9 @@ describe('BudgetService', () => {
       await service.createBudget(createDto, userId);
       await service.createBudget({ ...createDto, amount: 600 }, otherUserId);
 
-      const userBudgets = await service.getAllBudgets(userId);
-      const otherUserBudgets = await service.getAllBudgets(otherUserId);
+      const { data: userBudgets } = await service.getAllBudgets(userId);
+      const { data: otherUserBudgets } =
+        await service.getAllBudgets(otherUserId);
 
       expect(userBudgets).toHaveLength(1);
       expect(userBudgets[0].amount).toBe('500.00');

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -6,9 +6,11 @@ import {
 } from '@nestjs/common';
 import { BudgetType, Prisma, TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
+import { PaginatedResponse } from '@my-pocket/shared';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
+import { GetBudgetsQueryDto } from './dto/get-budgets-query.dto';
 import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
 import { formatDecimal } from '../shared';
@@ -195,15 +197,49 @@ export class BudgetService {
     return Number(spent._sum.amount ?? 0);
   }
 
-  async getAllBudgets(userId: string) {
-    const budgets = await this.prisma.budget.findMany({
-      where: { userId },
-      select: this.budgetSelect,
-    });
-    return budgets.map((budget) => {
-      const { userId: _userId, ...budgetWithoutUserId } = budget;
-      return this.mapBudget(budgetWithoutUserId);
-    });
+  async getAllBudgets(
+    userId: string,
+    query: GetBudgetsQueryDto = {},
+  ): Promise<PaginatedResponse<ReturnType<typeof this.mapBudget>>> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const where: Record<string, unknown> = { userId };
+
+    if (query.month !== undefined) {
+      where['month'] = query.month;
+    }
+
+    if (query.year !== undefined) {
+      where['year'] = query.year;
+    }
+
+    if (query.type) {
+      where['type'] = query.type as BudgetType;
+    }
+
+    const [budgets, total] = await Promise.all([
+      this.prisma.budget.findMany({
+        where,
+        select: this.budgetSelect,
+        skip,
+        take: limit,
+        orderBy: [{ year: 'desc' }, { month: 'desc' }],
+      }),
+      this.prisma.budget.count({ where }),
+    ]);
+
+    return {
+      data: budgets.map((budget) => {
+        const { userId: _userId, ...budgetWithoutUserId } = budget;
+        return this.mapBudget(budgetWithoutUserId);
+      }),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
   }
 
   async getBudgetById(id: string, userId: string) {

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -221,7 +221,7 @@ export class BudgetService {
     }
 
     if (query.type) {
-      where['type'] = query.type as BudgetType;
+      where['type'] = query.type;
     }
 
     const [budgets, total] = await Promise.all([

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -6,7 +6,6 @@ import {
 } from '@nestjs/common';
 import { BudgetType, Prisma, TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
-import { PaginatedResponse } from '@my-pocket/shared';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
@@ -200,7 +199,13 @@ export class BudgetService {
   async getAllBudgets(
     userId: string,
     query: GetBudgetsQueryDto = {},
-  ): Promise<PaginatedResponse<ReturnType<typeof this.mapBudget>>> {
+  ): Promise<{
+    data: ReturnType<typeof this.mapBudget>[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
     const skip = (page - 1) * limit;

--- a/apps/api/src/modules/budgets/budget.swagger.ts
+++ b/apps/api/src/modules/budgets/budget.swagger.ts
@@ -1,15 +1,44 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { BudgetDto } from './dto/budget.dto';
 import { BudgetWithSpendingDto } from './dto/budget-with-spending.dto';
 
 export function ApiGetAllBudgets() {
   return applyDecorators(
     ApiOperation({ summary: 'Get all budgets' }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: 'Page number (default: 1)',
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: 'Items per page (default: 20)',
+    }),
+    ApiQuery({
+      name: 'month',
+      required: false,
+      type: Number,
+      description: 'Filter by month (1-12)',
+    }),
+    ApiQuery({
+      name: 'year',
+      required: false,
+      type: Number,
+      description: 'Filter by year (>= 2000)',
+    }),
+    ApiQuery({
+      name: 'type',
+      required: false,
+      enum: ['INCOME', 'EXPENSE'],
+      description: 'Filter by budget type',
+    }),
     ApiResponse({
       status: 200,
-      description: 'List of all budgets for the authenticated user',
-      type: [BudgetDto],
+      description: 'Paginated list of budgets for the authenticated user',
     }),
     ApiResponse({
       status: 401,

--- a/apps/api/src/modules/budgets/dto/get-budgets-query.dto.ts
+++ b/apps/api/src/modules/budgets/dto/get-budgets-query.dto.ts
@@ -1,0 +1,34 @@
+import { IsEnum, IsInt, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { BudgetType } from '@my-pocket/shared';
+
+export class GetBudgetsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  year?: number;
+
+  @IsOptional()
+  @IsEnum(BudgetType)
+  type?: BudgetType;
+}

--- a/apps/api/src/modules/budgets/dto/get-budgets-query.dto.ts
+++ b/apps/api/src/modules/budgets/dto/get-budgets-query.dto.ts
@@ -1,6 +1,6 @@
 import { IsEnum, IsInt, IsOptional, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
-import { BudgetType } from '@my-pocket/shared';
+import { BudgetType } from '@prisma/client';
 
 export class GetBudgetsQueryDto {
   @IsOptional()

--- a/apps/api/src/modules/transactions/dto/get-transactions-query.dto.ts
+++ b/apps/api/src/modules/transactions/dto/get-transactions-query.dto.ts
@@ -7,7 +7,7 @@ import {
   Min,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { TransactionType } from '@my-pocket/shared';
+import { TransactionType } from '@prisma/client';
 
 export class GetTransactionsQueryDto {
   @IsOptional()

--- a/apps/api/src/modules/transactions/dto/get-transactions-query.dto.ts
+++ b/apps/api/src/modules/transactions/dto/get-transactions-query.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsUUID,
+  IsDateString,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { TransactionType } from '@my-pocket/shared';
+
+export class GetTransactionsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsEnum(TransactionType)
+  type?: TransactionType;
+
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/apps/api/src/modules/transactions/transactions.controller.ts
+++ b/apps/api/src/modules/transactions/transactions.controller.ts
@@ -35,10 +35,10 @@ export class TransactionController {
 
   @Get()
   @ApiGetAllTransactions()
-  async getAllTransactions(
+  getAllTransactions(
     @Request() req: AuthenticatedRequest,
     @Query() query: GetTransactionsQueryDto,
-  ) {
+  ): ReturnType<TransactionsService['getAllTransactions']> {
     return this.transactionsService.getAllTransactions(req.user.userId, query);
   }
 

--- a/apps/api/src/modules/transactions/transactions.controller.ts
+++ b/apps/api/src/modules/transactions/transactions.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   Put,
   ParseUUIDPipe,
+  Query,
   UseGuards,
   Request,
 } from '@nestjs/common';
@@ -21,6 +22,7 @@ import {
 } from './transactions.swagger';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
 
@@ -33,8 +35,11 @@ export class TransactionController {
 
   @Get()
   @ApiGetAllTransactions()
-  async getAllTransactions(@Request() req: AuthenticatedRequest) {
-    return this.transactionsService.getAllTransactions(req.user.userId);
+  async getAllTransactions(
+    @Request() req: AuthenticatedRequest,
+    @Query() query: GetTransactionsQueryDto,
+  ) {
+    return this.transactionsService.getAllTransactions(req.user.userId, query);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/transactions/transactions.service.spec.ts
+++ b/apps/api/src/modules/transactions/transactions.service.spec.ts
@@ -34,10 +34,18 @@ const createPrismaMock = () => {
 
   return {
     transaction: {
-      findMany: jest.fn(
+      findMany: jest.fn(({ where, skip, take }) => {
+        const filtered = store.filter(
+          (t) => !where?.userId || t.userId === where.userId,
+        );
+        const sliced =
+          typeof skip === 'number' ? filtered.slice(skip) : filtered;
+        return typeof take === 'number' ? sliced.slice(0, take) : sliced;
+      }),
+      count: jest.fn(
         ({ where }) =>
-          store.filter((t) => !where?.userId || t.userId === where.userId) ??
-          [],
+          store.filter((t) => !where?.userId || t.userId === where.userId)
+            .length,
       ),
       findUnique: jest.fn(
         ({ where: { id, userId } }) =>
@@ -145,9 +153,13 @@ describe('TransactionsService', () => {
   });
 
   describe('getAllTransactions', () => {
-    it('should return an empty array initially', async () => {
-      const transactions = await service.getAllTransactions(userId);
-      expect(transactions).toEqual([]);
+    it('should return an empty paginated result initially', async () => {
+      const result = await service.getAllTransactions(userId);
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.totalPages).toBe(0);
     });
 
     it('should return only user transactions filtered by userId', async () => {
@@ -166,12 +178,39 @@ describe('TransactionsService', () => {
       await service.createTransaction(createDto, userId);
       await service.createTransaction(createDto, otherUserId);
 
-      const userTransactions = await service.getAllTransactions(userId);
-      expect(userTransactions.length).toBe(2);
+      const userResult = await service.getAllTransactions(userId);
+      expect(userResult.data.length).toBe(2);
+      expect(userResult.total).toBe(2);
 
-      const otherUserTransactions =
-        await service.getAllTransactions(otherUserId);
-      expect(otherUserTransactions.length).toBe(1);
+      const otherUserResult = await service.getAllTransactions(otherUserId);
+      expect(otherUserResult.data.length).toBe(1);
+      expect(otherUserResult.total).toBe(1);
+    });
+
+    it('should return paginated response with pagination metadata', async () => {
+      jest.spyOn(categoriesService, 'getCategoryById').mockResolvedValue({
+        ...buildCategory(categoryId, 'Salary'),
+      });
+
+      const createDto: CreateTransactionDto = {
+        amount: 1000,
+        categoryId,
+        date: '2025-01-01',
+        description: 'Monthly salary',
+      };
+
+      await service.createTransaction(createDto, userId);
+      await service.createTransaction(createDto, userId);
+
+      const result = await service.getAllTransactions(userId, {
+        page: 1,
+        limit: 1,
+      });
+      expect(result.data.length).toBe(1);
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(1);
+      expect(result.totalPages).toBe(2);
     });
   });
 
@@ -304,10 +343,10 @@ describe('TransactionsService', () => {
       };
 
       await service.createTransaction(createDto, userId);
-      const allTransactions = await service.getAllTransactions(userId);
+      const result = await service.getAllTransactions(userId);
 
-      expect(allTransactions.length).toBe(1);
-      expect(allTransactions[0].amount).toBe('1000.00');
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].amount).toBe('1000.00');
     });
 
     it('should derive INCOME type from INCOME category', async () => {
@@ -374,7 +413,7 @@ describe('TransactionsService', () => {
         amount: 2000,
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       const updated = await service.updateTransaction(
         existing.id,
         updateDto,
@@ -396,7 +435,7 @@ describe('TransactionsService', () => {
         description: 'Bonus payment',
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       const updated = await service.updateTransaction(
         existing.id,
         updateDto,
@@ -434,7 +473,7 @@ describe('TransactionsService', () => {
         categoryId: otherCategoryId,
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
 
       await expect(
         service.updateTransaction(existing.id, updateDto, userId),
@@ -449,7 +488,7 @@ describe('TransactionsService', () => {
         amount: 2000,
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       const updated = await service.updateTransaction(
         existing.id,
         updateDto,
@@ -489,7 +528,7 @@ describe('TransactionsService', () => {
         categoryId: otherCategoryId,
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       const updated = await service.updateTransaction(
         existing.id,
         updateDto,
@@ -522,7 +561,7 @@ describe('TransactionsService', () => {
 
       await service.createTransaction(createDto, userId);
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       expect(existing.type).toBe(TransactionType.INCOME);
 
       const updated = await service.updateTransaction(
@@ -538,7 +577,7 @@ describe('TransactionsService', () => {
     });
 
     it('should not change type when categoryId is not updated', async () => {
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       expect(existing.type).toBe(TransactionType.INCOME);
 
       const updated = await service.updateTransaction(
@@ -558,7 +597,7 @@ describe('TransactionsService', () => {
         amount: 5000,
       };
 
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       await expect(
         service.updateTransaction(existing.id, updateDto, otherUserId),
       ).rejects.toThrow(NotFoundException);
@@ -595,7 +634,7 @@ describe('TransactionsService', () => {
     });
 
     it('should delete a transaction and return it', async () => {
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       const deleted = await service.deleteTransaction(existing.id, userId);
 
       expect(deleted).toBeDefined();
@@ -607,11 +646,11 @@ describe('TransactionsService', () => {
     });
 
     it('should remove transaction from array', async () => {
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       await service.deleteTransaction(existing.id, userId);
       const remaining = await service.getAllTransactions(userId);
 
-      expect(remaining.length).toBe(0);
+      expect(remaining.data.length).toBe(0);
     });
 
     it('should remove only the specified transaction', async () => {
@@ -628,16 +667,16 @@ describe('TransactionsService', () => {
 
       await service.createTransaction(createDto, userId);
 
-      const [first] = await service.getAllTransactions(userId);
+      const [first] = (await service.getAllTransactions(userId)).data;
       await service.deleteTransaction(first.id, userId);
       const remaining = await service.getAllTransactions(userId);
 
-      expect(remaining.length).toBe(1);
-      expect(remaining[0].id).not.toBe(first.id);
+      expect(remaining.data.length).toBe(1);
+      expect(remaining.data[0].id).not.toBe(first.id);
     });
 
     it('should return null when user tries to delete another users transaction', async () => {
-      const [existing] = await service.getAllTransactions(userId);
+      const [existing] = (await service.getAllTransactions(userId)).data;
       await expect(
         service.deleteTransaction(existing.id, otherUserId),
       ).rejects.toThrow(NotFoundException);

--- a/apps/api/src/modules/transactions/transactions.service.ts
+++ b/apps/api/src/modules/transactions/transactions.service.ts
@@ -5,7 +5,6 @@ import {
 } from '@nestjs/common';
 import { TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
-import { PaginatedResponse } from '@my-pocket/shared';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
@@ -53,7 +52,13 @@ export class TransactionsService {
   async getAllTransactions(
     userId: string,
     query: GetTransactionsQueryDto = {},
-  ): Promise<PaginatedResponse<ReturnType<typeof this.mapTransaction>>> {
+  ): Promise<{
+    data: ReturnType<typeof this.mapTransaction>[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
     const skip = (page - 1) * limit;

--- a/apps/api/src/modules/transactions/transactions.service.ts
+++ b/apps/api/src/modules/transactions/transactions.service.ts
@@ -66,7 +66,7 @@ export class TransactionsService {
     const where: Record<string, unknown> = { userId };
 
     if (query.type) {
-      where['type'] = query.type as TransactionType;
+      where['type'] = query.type;
     }
 
     if (query.categoryId) {

--- a/apps/api/src/modules/transactions/transactions.service.ts
+++ b/apps/api/src/modules/transactions/transactions.service.ts
@@ -5,8 +5,10 @@ import {
 } from '@nestjs/common';
 import { TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
+import { PaginatedResponse } from '@my-pocket/shared';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
 import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
 import { formatDecimal } from '../shared';
@@ -48,12 +50,55 @@ export class TransactionsService {
     userId: true,
   };
 
-  async getAllTransactions(userId: string) {
-    const transactions = await this.prisma.transaction.findMany({
-      where: { userId },
-      select: this.transactionSelect,
-    });
-    return transactions.map((transaction) => this.mapTransaction(transaction));
+  async getAllTransactions(
+    userId: string,
+    query: GetTransactionsQueryDto = {},
+  ): Promise<PaginatedResponse<ReturnType<typeof this.mapTransaction>>> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const where: Record<string, unknown> = { userId };
+
+    if (query.type) {
+      where['type'] = query.type as TransactionType;
+    }
+
+    if (query.categoryId) {
+      where['categoryId'] = query.categoryId;
+    }
+
+    if (query.startDate || query.endDate) {
+      const dateFilter: Record<string, Date> = {};
+      if (query.startDate) {
+        dateFilter['gte'] = new Date(query.startDate);
+      }
+      if (query.endDate) {
+        dateFilter['lte'] = new Date(
+          `${query.endDate.slice(0, 10)}T23:59:59.999Z`,
+        );
+      }
+      where['date'] = dateFilter;
+    }
+
+    const [transactions, total] = await Promise.all([
+      this.prisma.transaction.findMany({
+        where,
+        select: this.transactionSelect,
+        skip,
+        take: limit,
+        orderBy: { date: 'desc' },
+      }),
+      this.prisma.transaction.count({ where }),
+    ]);
+
+    return {
+      data: transactions.map((transaction) => this.mapTransaction(transaction)),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
   }
 
   async getTransactionById(id: string, userId: string) {

--- a/apps/api/src/modules/transactions/transactions.swagger.ts
+++ b/apps/api/src/modules/transactions/transactions.swagger.ts
@@ -1,14 +1,49 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { TransactionDto } from './dto/transaction.dto';
 
 export function ApiGetAllTransactions() {
   return applyDecorators(
     ApiOperation({ summary: 'Get all transactions' }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: 'Page number (default: 1)',
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: 'Items per page (default: 20)',
+    }),
+    ApiQuery({
+      name: 'type',
+      required: false,
+      enum: ['INCOME', 'EXPENSE'],
+      description: 'Filter by transaction type',
+    }),
+    ApiQuery({
+      name: 'categoryId',
+      required: false,
+      type: String,
+      description: 'Filter by category UUID',
+    }),
+    ApiQuery({
+      name: 'startDate',
+      required: false,
+      type: String,
+      description: 'Filter from date (ISO 8601)',
+    }),
+    ApiQuery({
+      name: 'endDate',
+      required: false,
+      type: String,
+      description: 'Filter to date (ISO 8601)',
+    }),
     ApiResponse({
       status: 200,
-      description: 'List of all transactions for the authenticated user',
-      type: [TransactionDto],
+      description: 'Paginated list of transactions for the authenticated user',
     }),
     ApiResponse({
       status: 401,

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -532,7 +532,7 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .expect(200);
 
-        const filtered = transactionsResponse.body.filter(
+        const filtered = transactionsResponse.body.data.filter(
           (t: any) => t.categoryId === catId,
         );
         expect(filtered.length).toBe(0);
@@ -650,11 +650,11 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .expect(200);
 
-        expect(Array.isArray(response.body)).toBe(true);
-        expect(response.body.length).toBeGreaterThan(0);
-        expect(response.body.some((t: any) => t.id === transactionId)).toBe(
-          true,
-        );
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBeGreaterThan(0);
+        expect(
+          response.body.data.some((t: any) => t.id === transactionId),
+        ).toBe(true);
       });
 
       it('should not return other users transactions', async () => {
@@ -664,7 +664,7 @@ describe('Personal Finance API E2E', () => {
           .expect(200);
 
         expect(
-          user2Response.body.every((t: any) => t.id !== transactionId),
+          user2Response.body.data.every((t: any) => t.id !== transactionId),
         ).toBe(true);
       });
 
@@ -910,8 +910,10 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user1Token}`)
           .expect(200);
 
-        expect(Array.isArray(response.body)).toBe(true);
-        expect(response.body.some((b: any) => b.id === budgetId)).toBe(true);
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.some((b: any) => b.id === budgetId)).toBe(
+          true,
+        );
       });
 
       it('should not return other users budgets', async () => {
@@ -920,7 +922,9 @@ describe('Personal Finance API E2E', () => {
           .set('Authorization', `Bearer ${user2Token}`)
           .expect(200);
 
-        expect(response.body.every((b: any) => b.id !== budgetId)).toBe(true);
+        expect(response.body.data.every((b: any) => b.id !== budgetId)).toBe(
+          true,
+        );
       });
 
       it('should reject without authentication', async () => {

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -6,6 +6,9 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
+  "moduleNameMapper": {
+    "^@my-pocket/shared$": "<rootDir>/../../../node_modules/@my-pocket/shared/dist/index.js"
+  },
   "setupFilesAfterEnv": ["<rootDir>/setup.ts"],
   "testTimeout": 30000
 }

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -7,7 +7,7 @@
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "moduleNameMapper": {
-    "^@my-pocket/shared$": "<rootDir>/../../../node_modules/@my-pocket/shared/dist/index.js"
+    "^@my-pocket/shared$": "<rootDir>/../../../packages/shared/src/index.ts"
   },
   "setupFilesAfterEnv": ["<rootDir>/setup.ts"],
   "testTimeout": 30000

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -391,5 +391,10 @@
     "10": "October",
     "11": "November",
     "12": "December"
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {page} of {totalPages}"
   }
 }

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -391,5 +391,10 @@
     "10": "Outubro",
     "11": "Novembro",
     "12": "Dezembro"
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Próximo",
+    "pageOf": "Página {page} de {totalPages}"
   }
 }

--- a/apps/web/src/app/budgets/page.test.tsx
+++ b/apps/web/src/app/budgets/page.test.tsx
@@ -12,6 +12,14 @@ import BudgetsPage from './page';
 
 const API_URL = 'http://localhost:3001';
 
+const makePaginatedResponse = <T,>(data: T[], page = 1, limit = 20) => ({
+  data,
+  total: data.length,
+  page,
+  limit,
+  totalPages: Math.ceil(data.length / limit),
+});
+
 // Mock next/navigation — return a stable router reference to avoid useCallback re-creation loops
 const mockRouterPush = vi.fn();
 const _mockBudgetsRouter = {
@@ -70,7 +78,7 @@ describe('BudgetsPage', () => {
   it('shows empty state when no budgets exist', async () => {
     server.use(
       http.get(`${API_URL}/budgets`, () => {
-        return HttpResponse.json([]);
+        return HttpResponse.json(makePaginatedResponse([]));
       }),
     );
 
@@ -85,22 +93,6 @@ describe('BudgetsPage', () => {
     });
   });
 
-  it('shows "no matches" message when filters yield no results', async () => {
-    const user = setupUser();
-    renderWithAuthenticatedProviders(<BudgetsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('$500.00')).toBeInTheDocument();
-    });
-
-    // Filter by month that has no budget (December) - mock data has March only
-    await selectOption(user, screen.getByTestId('month-filter'), 'December');
-
-    expect(
-      screen.getByText('No budgets match your filters.'),
-    ).toBeInTheDocument();
-  });
-
   it('filters budgets by type', async () => {
     const user = setupUser();
     renderWithAuthenticatedProviders(<BudgetsPage />);
@@ -109,11 +101,23 @@ describe('BudgetsPage', () => {
       expect(screen.getByText('$500.00')).toBeInTheDocument();
     });
 
-    // Filter by INCOME
+    // Filter by INCOME — re-fetches from API
+    server.use(
+      http.get(`${API_URL}/budgets`, ({ request }) => {
+        const url = new URL(request.url);
+        const type = url.searchParams.get('type');
+        const data = type
+          ? mockBudgets.filter((b) => b.type === type)
+          : mockBudgets;
+        return HttpResponse.json(makePaginatedResponse(data));
+      }),
+    );
+
     await selectOption(user, screen.getByTestId('type-filter'), 'Income');
 
-    // Only INCOME budget should be visible
-    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    });
     expect(screen.queryByText('$500.00')).not.toBeInTheDocument();
   });
 
@@ -121,20 +125,30 @@ describe('BudgetsPage', () => {
     const user = setupUser();
 
     // Add more budgets with different months
+    const extendedBudgets = [
+      ...mockBudgets,
+      {
+        id: 'budget-3',
+        amount: '200.00',
+        categoryId: 'cat-2',
+        month: 4,
+        year: 2026,
+        type: 'EXPENSE',
+        userId: 'test-user-id',
+      },
+    ];
+
     server.use(
-      http.get(`${API_URL}/budgets`, () => {
-        return HttpResponse.json([
-          ...mockBudgets,
-          {
-            id: 'budget-3',
-            amount: '200.00',
-            categoryId: 'cat-2',
-            month: 4,
-            year: 2026,
-            type: 'EXPENSE',
-            userId: 'test-user-id',
-          },
-        ]);
+      http.get(`${API_URL}/budgets`, ({ request }) => {
+        const url = new URL(request.url);
+        const month = url.searchParams.get('month')
+          ? parseInt(url.searchParams.get('month')!)
+          : undefined;
+        const data =
+          month !== undefined
+            ? extendedBudgets.filter((b) => b.month === month)
+            : extendedBudgets;
+        return HttpResponse.json(makePaginatedResponse(data));
       }),
     );
 
@@ -147,8 +161,9 @@ describe('BudgetsPage', () => {
     // Filter by month 4 (April)
     await selectOption(user, screen.getByTestId('month-filter'), 'April');
 
-    // Only April budget should be visible
-    expect(screen.getByText('$200.00')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('$200.00')).toBeInTheDocument();
+    });
     expect(screen.queryByText('$500.00')).not.toBeInTheDocument();
     expect(screen.queryByText('$3,000.00')).not.toBeInTheDocument();
   });
@@ -157,20 +172,30 @@ describe('BudgetsPage', () => {
     const user = setupUser();
 
     // Add budget with different year
+    const extendedBudgets = [
+      ...mockBudgets,
+      {
+        id: 'budget-3',
+        amount: '750.00',
+        categoryId: 'cat-1',
+        month: 3,
+        year: 2025,
+        type: 'INCOME',
+        userId: 'test-user-id',
+      },
+    ];
+
     server.use(
-      http.get(`${API_URL}/budgets`, () => {
-        return HttpResponse.json([
-          ...mockBudgets,
-          {
-            id: 'budget-3',
-            amount: '750.00',
-            categoryId: 'cat-1',
-            month: 3,
-            year: 2025,
-            type: 'INCOME',
-            userId: 'test-user-id',
-          },
-        ]);
+      http.get(`${API_URL}/budgets`, ({ request }) => {
+        const url = new URL(request.url);
+        const year = url.searchParams.get('year')
+          ? parseInt(url.searchParams.get('year')!)
+          : undefined;
+        const data =
+          year !== undefined
+            ? extendedBudgets.filter((b) => b.year === year)
+            : extendedBudgets;
+        return HttpResponse.json(makePaginatedResponse(data));
       }),
     );
 
@@ -183,8 +208,9 @@ describe('BudgetsPage', () => {
     // Filter by 2025
     await selectOption(user, screen.getByTestId('year-filter'), '2025');
 
-    // Only 2025 budget should be visible
-    expect(screen.getByText('$750.00')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('$750.00')).toBeInTheDocument();
+    });
     expect(screen.queryByText('$500.00')).not.toBeInTheDocument();
     expect(screen.queryByText('$3,000.00')).not.toBeInTheDocument();
   });
@@ -366,55 +392,6 @@ describe('BudgetsPage', () => {
     expect(screen.getByText('$500.00')).toBeInTheDocument();
   });
 
-  it('combines multiple filters', async () => {
-    const user = setupUser();
-
-    // Add more budgets for better filter testing
-    server.use(
-      http.get(`${API_URL}/budgets`, () => {
-        return HttpResponse.json([
-          ...mockBudgets,
-          {
-            id: 'budget-3',
-            amount: '1500.00',
-            categoryId: 'cat-1',
-            month: 4,
-            year: 2026,
-            type: 'INCOME',
-            userId: 'test-user-id',
-          },
-          {
-            id: 'budget-4',
-            amount: '800.00',
-            categoryId: 'cat-2',
-            month: 4,
-            year: 2026,
-            type: 'EXPENSE',
-            userId: 'test-user-id',
-          },
-        ]);
-      }),
-    );
-
-    renderWithAuthenticatedProviders(<BudgetsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('$500.00')).toBeInTheDocument();
-    });
-
-    // Filter by month 4 (April)
-    await selectOption(user, screen.getByTestId('month-filter'), 'April');
-
-    // Filter by INCOME type
-    await selectOption(user, screen.getByTestId('type-filter'), 'Income');
-
-    // Only April INCOME budget should be visible
-    expect(screen.getByText('$1,500.00')).toBeInTheDocument();
-    expect(screen.queryByText('$500.00')).not.toBeInTheDocument();
-    expect(screen.queryByText('$3,000.00')).not.toBeInTheDocument();
-    expect(screen.queryByText('$800.00')).not.toBeInTheDocument();
-  });
-
   it('displays period as Month/Year format', async () => {
     renderWithAuthenticatedProviders(<BudgetsPage />);
 
@@ -425,5 +402,65 @@ describe('BudgetsPage', () => {
     // Period should show month name and year
     const periodCells = screen.getAllByText('March 2026');
     expect(periodCells.length).toBeGreaterThan(0);
+  });
+
+  it('shows year filter using static year range', async () => {
+    renderWithAuthenticatedProviders(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$500.00')).toBeInTheDocument();
+    });
+
+    // The year filter should contain current year
+    const currentYear = new Date().getFullYear();
+    const yearTrigger = screen.getByTestId('year-filter');
+    expect(yearTrigger).toBeInTheDocument();
+    // Static year range includes currentYear+1 down to 2020
+    const user = setupUser();
+    await user.click(yearTrigger);
+    await waitFor(() => {
+      expect(screen.getAllByText(String(currentYear))[0]).toBeInTheDocument();
+    });
+  });
+
+  it('shows pagination when totalPages > 1', async () => {
+    server.use(
+      http.get(`${API_URL}/budgets`, () => {
+        return HttpResponse.json({
+          data: [mockBudgets[0]],
+          total: 40,
+          page: 1,
+          limit: 20,
+          totalPages: 2,
+        });
+      }),
+    );
+
+    renderWithAuthenticatedProviders(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$500.00')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Previous' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('pagination hidden when totalPages <= 1', async () => {
+    renderWithAuthenticatedProviders(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$500.00')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Previous' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Next' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
-import { PaginatedResponse } from '@my-pocket/shared';
+import { PaginatedResponse } from '@/lib/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { budgetsApi, GetBudgetsParams } from '@/lib/budgets';
 import { categoriesApi } from '@/lib/categories';

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
+import { PaginatedResponse } from '@my-pocket/shared';
 import { useAuth } from '@/contexts/AuthContext';
-import { budgetsApi } from '@/lib/budgets';
+import { budgetsApi, GetBudgetsParams } from '@/lib/budgets';
 import { categoriesApi } from '@/lib/categories';
 import { Budget, Category, BudgetType } from '@/types';
 import { AuthLayout } from '@/components/layouts/AuthLayout';
 import { BudgetsTableSkeleton } from '@/components/BudgetsTableSkeleton';
+import { Pagination } from '@/components/Pagination';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -60,12 +62,6 @@ function getProgressValue(budget: BudgetDisplay): string | undefined {
   return budget.spent;
 }
 
-// Get unique years from budgets for the filter
-function getUniqueYears(budgets: BudgetDisplay[]): number[] {
-  const years = [...new Set(budgets.map((b) => b.year))];
-  return years.sort((a, b) => b - a); // Sort descending
-}
-
 function getUtilizationColor(
   percentage: number | undefined,
   budgetType?: BudgetType,
@@ -82,7 +78,10 @@ function getUtilizationColor(
 }
 
 export default function BudgetsPage() {
-  const [budgets, setBudgets] = useState<BudgetDisplay[]>([]);
+  const [budgets, setBudgets] = useState<PaginatedResponse<Budget> | null>(
+    null,
+  );
+  const [categoryBudgets, setCategoryBudgets] = useState<BudgetDisplay[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deleteBudget, setDeleteBudget] = useState<BudgetDisplay | null>(null);
@@ -92,6 +91,7 @@ export default function BudgetsPage() {
   const [filterType, setFilterType] = useState<FilterType>('ALL');
   const [filterCategory, setFilterCategory] = useState<FilterCategory>('ALL');
   const [hasSpendingInfo, setHasSpendingInfo] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
   const { isAuthenticated, logout } = useAuth();
   const router = useRouter();
   const t = useTranslations('budgets');
@@ -99,29 +99,22 @@ export default function BudgetsPage() {
   const tMonths = useTranslations('months');
   const locale = useLocale();
 
+  const currentYear = new Date().getFullYear();
   const MONTHS = Array.from({ length: 12 }, (_, i) => ({
     value: i + 1,
     label: tMonths(String(i + 1)),
   }));
 
-  const loadAllBudgets = useCallback(async () => {
-    try {
-      const budgetsData = await budgetsApi.getAll();
-      setBudgets(budgetsData);
-      setHasSpendingInfo(false);
-    } catch (error) {
-      if (error instanceof ApiException) {
-        if (error.statusCode === 401) {
-          logout();
-          router.push('/login');
-          return;
-        }
-        toast.error(error.message);
-      } else {
-        toast.error(t('failedToLoad'));
-      }
-    }
-  }, [logout, router, t]);
+  const YEARS = Array.from(
+    { length: currentYear - 2020 + 2 },
+    (_, i) => currentYear + 1 - i,
+  );
+
+  // Stable router ref to avoid re-creating loadBudgetsByCategory
+  const routerRef = useRef(router);
+  routerRef.current = router;
+  const logoutRef = useRef(logout);
+  logoutRef.current = logout;
 
   const loadBudgetsByCategory = useCallback(
     async (categoryId: string) => {
@@ -132,13 +125,13 @@ export default function BudgetsPage() {
           ...b,
           userId: '',
         }));
-        setBudgets(budgetsWithUserId);
+        setCategoryBudgets(budgetsWithUserId);
         setHasSpendingInfo(true);
       } catch (error) {
         if (error instanceof ApiException) {
           if (error.statusCode === 401) {
-            logout();
-            router.push('/login');
+            logoutRef.current();
+            routerRef.current.push('/login');
             return;
           }
           toast.error(error.message);
@@ -147,7 +140,7 @@ export default function BudgetsPage() {
         }
       }
     },
-    [logout, router, t],
+    [t],
   );
 
   useEffect(() => {
@@ -168,18 +161,49 @@ export default function BudgetsPage() {
     if (isAuthenticated) {
       loadCategories();
     }
-  }, [isAuthenticated, logout, router, t]);
+  }, [isAuthenticated]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isAuthenticated) return;
 
     setIsLoading(true);
     if (filterCategory === 'ALL') {
-      loadAllBudgets().finally(() => setIsLoading(false));
+      const params: GetBudgetsParams = { page: currentPage, limit: 20 };
+      if (filterMonth !== 'ALL') params.month = filterMonth as number;
+      if (filterYear !== 'ALL') params.year = filterYear as number;
+      if (filterType !== 'ALL') params.type = filterType;
+
+      budgetsApi
+        .getAll(params)
+        .then((data) => {
+          setBudgets(data);
+          setHasSpendingInfo(false);
+        })
+        .catch((error) => {
+          if (error instanceof ApiException) {
+            if (error.statusCode === 401) {
+              logoutRef.current();
+              routerRef.current.push('/login');
+              return;
+            }
+            toast.error(error.message);
+          } else {
+            toast.error(t('failedToLoad'));
+          }
+        })
+        .finally(() => setIsLoading(false));
     } else {
       loadBudgetsByCategory(filterCategory).finally(() => setIsLoading(false));
     }
-  }, [isAuthenticated, filterCategory, loadAllBudgets, loadBudgetsByCategory]);
+  }, [
+    isAuthenticated,
+    filterCategory,
+    filterMonth,
+    filterYear,
+    filterType,
+    currentPage,
+    loadBudgetsByCategory,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const categoryMap = useMemo(() => {
     return categories.reduce(
@@ -191,17 +215,29 @@ export default function BudgetsPage() {
     );
   }, [categories]);
 
-  const availableYears = useMemo(() => getUniqueYears(budgets), [budgets]);
+  // The displayed budgets depend on whether we're in category filter mode
+  const displayedBudgets: BudgetDisplay[] =
+    filterCategory === 'ALL' ? (budgets?.data ?? []) : categoryBudgets;
 
-  const filteredBudgets = useMemo(() => {
-    return budgets.filter((budget) => {
-      const matchesMonth =
-        filterMonth === 'ALL' || budget.month === filterMonth;
-      const matchesYear = filterYear === 'ALL' || budget.year === filterYear;
-      const matchesType = filterType === 'ALL' || budget.type === filterType;
-      return matchesMonth && matchesYear && matchesType;
-    });
-  }, [budgets, filterMonth, filterYear, filterType]);
+  const handleFilterMonthChange = (value: string) => {
+    setFilterMonth(value === 'ALL' ? 'ALL' : parseInt(value));
+    setCurrentPage(1);
+  };
+
+  const handleFilterYearChange = (value: string) => {
+    setFilterYear(value === 'ALL' ? 'ALL' : parseInt(value));
+    setCurrentPage(1);
+  };
+
+  const handleFilterTypeChange = (value: FilterType) => {
+    setFilterType(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterCategoryChange = (value: FilterCategory) => {
+    setFilterCategory(value);
+    setCurrentPage(1);
+  };
 
   const handleDelete = async () => {
     if (!deleteBudget) return;
@@ -209,7 +245,28 @@ export default function BudgetsPage() {
     setIsDeleting(true);
     try {
       await budgetsApi.delete(deleteBudget.id);
-      setBudgets((prev) => prev.filter((b) => b.id !== deleteBudget.id));
+      if (filterCategory === 'ALL') {
+        setBudgets((prev) => {
+          if (!prev) return prev;
+          const newData = prev.data.filter((b) => b.id !== deleteBudget.id);
+          const newTotal = prev.total - 1;
+          const newTotalPages = Math.ceil(newTotal / prev.limit);
+          if (newData.length === 0 && currentPage > 1) {
+            setCurrentPage((p) => p - 1);
+            return prev;
+          }
+          return {
+            ...prev,
+            data: newData,
+            total: newTotal,
+            totalPages: newTotalPages,
+          };
+        });
+      } else {
+        setCategoryBudgets((prev) =>
+          prev.filter((b) => b.id !== deleteBudget.id),
+        );
+      }
       toast.success(t('deleteSuccess'));
       setDeleteBudget(null);
     } catch (error) {
@@ -223,6 +280,16 @@ export default function BudgetsPage() {
     }
   };
 
+  const isEmpty =
+    filterCategory === 'ALL'
+      ? !budgets || (budgets.data.length === 0 && budgets.total === 0)
+      : categoryBudgets.length === 0;
+
+  const hasNoMatch =
+    filterCategory === 'ALL'
+      ? budgets?.data.length === 0 && (budgets?.total ?? 0) > 0
+      : false;
+
   return (
     <AuthLayout>
       <div className="flex items-center justify-between mb-6">
@@ -235,9 +302,7 @@ export default function BudgetsPage() {
       <div className="flex flex-wrap gap-4 mb-4">
         <Select
           value={filterMonth === 'ALL' ? 'ALL' : String(filterMonth)}
-          onValueChange={(value) =>
-            setFilterMonth(value === 'ALL' ? 'ALL' : parseInt(value))
-          }
+          onValueChange={handleFilterMonthChange}
         >
           <SelectTrigger
             className="w-full sm:w-[150px]"
@@ -257,9 +322,7 @@ export default function BudgetsPage() {
 
         <Select
           value={filterYear === 'ALL' ? 'ALL' : String(filterYear)}
-          onValueChange={(value) =>
-            setFilterYear(value === 'ALL' ? 'ALL' : parseInt(value))
-          }
+          onValueChange={handleFilterYearChange}
         >
           <SelectTrigger
             className="w-full sm:w-[120px]"
@@ -269,7 +332,7 @@ export default function BudgetsPage() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="ALL">{tCommon('allYears')}</SelectItem>
-            {availableYears.map((year) => (
+            {YEARS.map((year) => (
               <SelectItem key={year} value={String(year)}>
                 {year}
               </SelectItem>
@@ -279,7 +342,7 @@ export default function BudgetsPage() {
 
         <Select
           value={filterType}
-          onValueChange={(value) => setFilterType(value as FilterType)}
+          onValueChange={(value) => handleFilterTypeChange(value as FilterType)}
         >
           <SelectTrigger
             className="w-full sm:w-[150px]"
@@ -296,7 +359,9 @@ export default function BudgetsPage() {
 
         <Select
           value={filterCategory}
-          onValueChange={(value) => setFilterCategory(value as FilterCategory)}
+          onValueChange={(value) =>
+            handleFilterCategoryChange(value as FilterCategory)
+          }
         >
           <SelectTrigger
             className="w-full sm:w-[180px]"
@@ -324,11 +389,11 @@ export default function BudgetsPage() {
       <div className="bg-card rounded-lg shadow">
         {isLoading ? (
           <BudgetsTableSkeleton />
-        ) : budgets.length === 0 ? (
+        ) : isEmpty ? (
           <div className="p-8 text-center text-muted-foreground">
             {t('noBudgets')}
           </div>
-        ) : filteredBudgets.length === 0 ? (
+        ) : hasNoMatch ? (
           <div className="p-8 text-center text-muted-foreground">
             {t('noMatch')}
           </div>
@@ -354,7 +419,7 @@ export default function BudgetsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredBudgets.map((budget) => {
+                {displayedBudgets.map((budget) => {
                   const progressValue = getProgressValue(budget);
                   return (
                     <TableRow
@@ -436,6 +501,15 @@ export default function BudgetsPage() {
           </div>
         )}
       </div>
+
+      {filterCategory === 'ALL' && budgets && (
+        <Pagination
+          page={budgets.page}
+          totalPages={budgets.totalPages}
+          onPageChange={setCurrentPage}
+          disabled={isLoading}
+        />
+      )}
 
       <Dialog open={!!deleteBudget} onOpenChange={() => setDeleteBudget(null)}>
         <DialogContent>

--- a/apps/web/src/app/transactions/page.test.tsx
+++ b/apps/web/src/app/transactions/page.test.tsx
@@ -12,6 +12,18 @@ import TransactionsPage from './page';
 
 const API_URL = 'http://localhost:3001';
 
+const makePaginatedResponse = (
+  data: typeof mockTransactions,
+  page = 1,
+  limit = 20,
+) => ({
+  data,
+  total: data.length,
+  page,
+  limit,
+  totalPages: Math.ceil(data.length / limit),
+});
+
 // Mock next/navigation
 const mockRouterPush = vi.fn();
 vi.mock('next/navigation', async () => ({
@@ -79,7 +91,7 @@ describe('TransactionsPage', () => {
   it('shows empty state when no transactions exist', async () => {
     server.use(
       http.get(`${API_URL}/transactions`, () => {
-        return HttpResponse.json([]);
+        return HttpResponse.json(makePaginatedResponse([]));
       }),
     );
 
@@ -94,28 +106,6 @@ describe('TransactionsPage', () => {
     });
   });
 
-  it('shows "no matches" message when filters yield no results', async () => {
-    const user = setupUser();
-    renderWithAuthenticatedProviders(<TransactionsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('$150.00')).toBeInTheDocument();
-    });
-
-    // Filter by date range that has no transactions
-    const startDateInput = screen.getByLabelText('Start Date');
-    await user.clear(startDateInput);
-    await user.type(startDateInput, '2025-01-01');
-
-    const endDateInput = screen.getByLabelText('End Date');
-    await user.clear(endDateInput);
-    await user.type(endDateInput, '2025-01-31');
-
-    expect(
-      screen.getByText('No transactions match your filters.'),
-    ).toBeInTheDocument();
-  });
-
   it('filters transactions by type', async () => {
     const user = setupUser();
     renderWithAuthenticatedProviders(<TransactionsPage />);
@@ -124,11 +114,23 @@ describe('TransactionsPage', () => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
     });
 
-    // Filter by INCOME
+    // Filter by INCOME — re-fetches from API
+    server.use(
+      http.get(`${API_URL}/transactions`, ({ request }) => {
+        const url = new URL(request.url);
+        const type = url.searchParams.get('type');
+        const data = type
+          ? mockTransactions.filter((t) => t.type === type)
+          : mockTransactions;
+        return HttpResponse.json(makePaginatedResponse(data));
+      }),
+    );
+
     await selectOption(user, screen.getByTestId('type-filter'), 'Income');
 
-    // Only INCOME transaction should be visible
-    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    });
     expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
   });
 
@@ -140,56 +142,24 @@ describe('TransactionsPage', () => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
     });
 
-    // Filter by Salary category
-    await selectOption(user, screen.getByTestId('category-filter'), 'Salary');
-
-    // Only transaction with Salary category should be visible
-    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
-    expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
-  });
-
-  it('filters transactions by date range', async () => {
-    const user = setupUser();
-
-    // Add transactions with different dates
+    // Filter by Salary category — re-fetches from API
     server.use(
-      http.get(`${API_URL}/transactions`, () => {
-        return HttpResponse.json([
-          ...mockTransactions,
-          {
-            id: 'transaction-3',
-            amount: '200.00',
-            type: 'EXPENSE',
-            categoryId: 'cat-2',
-            date: '2026-02-15T10:00:00.000Z',
-            description: 'February expense',
-            userId: 'test-user-id',
-            createdAt: '2026-02-15T10:00:00.000Z',
-            updatedAt: '2026-02-15T10:00:00.000Z',
-          },
-        ]);
+      http.get(`${API_URL}/transactions`, ({ request }) => {
+        const url = new URL(request.url);
+        const categoryId = url.searchParams.get('categoryId');
+        const data = categoryId
+          ? mockTransactions.filter((t) => t.categoryId === categoryId)
+          : mockTransactions;
+        return HttpResponse.json(makePaginatedResponse(data));
       }),
     );
 
-    renderWithAuthenticatedProviders(<TransactionsPage />);
+    await selectOption(user, screen.getByTestId('category-filter'), 'Salary');
 
     await waitFor(() => {
-      expect(screen.getByText('$150.00')).toBeInTheDocument();
+      expect(screen.getByText('$3,000.00')).toBeInTheDocument();
     });
-
-    // Filter by date range for March only
-    const startDateInput = screen.getByLabelText('Start Date');
-    await user.clear(startDateInput);
-    await user.type(startDateInput, '2026-03-01');
-
-    const endDateInput = screen.getByLabelText('End Date');
-    await user.clear(endDateInput);
-    await user.type(endDateInput, '2026-03-31');
-
-    // Only March transactions should be visible
-    expect(screen.getByText('$150.00')).toBeInTheDocument();
-    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
-    expect(screen.queryByText('$200.00')).not.toBeInTheDocument();
+    expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
   });
 
   it('has New Transaction button that links to create page', async () => {
@@ -377,65 +347,6 @@ describe('TransactionsPage', () => {
     expect(screen.getByText('$150.00')).toBeInTheDocument();
   });
 
-  it('combines multiple filters', async () => {
-    const user = setupUser();
-
-    // Add more transactions for better filter testing
-    server.use(
-      http.get(`${API_URL}/transactions`, () => {
-        return HttpResponse.json([
-          ...mockTransactions,
-          {
-            id: 'transaction-3',
-            amount: '1500.00',
-            type: 'INCOME',
-            categoryId: 'cat-1',
-            date: '2026-04-15T10:00:00.000Z',
-            description: 'April income',
-            userId: 'test-user-id',
-            createdAt: '2026-04-15T10:00:00.000Z',
-            updatedAt: '2026-04-15T10:00:00.000Z',
-          },
-          {
-            id: 'transaction-4',
-            amount: '800.00',
-            type: 'EXPENSE',
-            categoryId: 'cat-2',
-            date: '2026-04-20T10:00:00.000Z',
-            description: 'April expense',
-            userId: 'test-user-id',
-            createdAt: '2026-04-20T10:00:00.000Z',
-            updatedAt: '2026-04-20T10:00:00.000Z',
-          },
-        ]);
-      }),
-    );
-
-    renderWithAuthenticatedProviders(<TransactionsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('$150.00')).toBeInTheDocument();
-    });
-
-    // Filter by date range (April)
-    const startDateInput = screen.getByLabelText('Start Date');
-    await user.clear(startDateInput);
-    await user.type(startDateInput, '2026-04-01');
-
-    const endDateInput = screen.getByLabelText('End Date');
-    await user.clear(endDateInput);
-    await user.type(endDateInput, '2026-04-30');
-
-    // Filter by INCOME type
-    await selectOption(user, screen.getByTestId('type-filter'), 'Income');
-
-    // Only April INCOME transaction should be visible
-    expect(screen.getByText('$1,500.00')).toBeInTheDocument();
-    expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
-    expect(screen.queryByText('$3,000.00')).not.toBeInTheDocument();
-    expect(screen.queryByText('$800.00')).not.toBeInTheDocument();
-  });
-
   it('displays date in formatted format', async () => {
     renderWithAuthenticatedProviders(<TransactionsPage />);
 
@@ -456,20 +367,72 @@ describe('TransactionsPage', () => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
     });
 
-    // Apply filter
+    // Apply filter — server returns only INCOME
+    server.use(
+      http.get(`${API_URL}/transactions`, ({ request }) => {
+        const url = new URL(request.url);
+        const type = url.searchParams.get('type');
+        const data = type
+          ? mockTransactions.filter((t) => t.type === type)
+          : mockTransactions;
+        return HttpResponse.json(makePaginatedResponse(data));
+      }),
+    );
+
     await selectOption(user, screen.getByTestId('type-filter'), 'Income');
 
-    // Only INCOME visible
-    expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
-    expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('$150.00')).not.toBeInTheDocument();
+      expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+    });
 
-    // Click clear filters
+    // Click clear filters — all transactions should come back
     await user.click(screen.getByRole('button', { name: 'Clear Filters' }));
 
-    // All transactions should be visible again
     await waitFor(() => {
       expect(screen.getByText('$150.00')).toBeInTheDocument();
     });
     expect(screen.getByText('$3,000.00')).toBeInTheDocument();
+  });
+
+  it('shows pagination when totalPages > 1', async () => {
+    server.use(
+      http.get(`${API_URL}/transactions`, () => {
+        return HttpResponse.json({
+          data: [mockTransactions[0]],
+          total: 40,
+          page: 1,
+          limit: 20,
+          totalPages: 2,
+        });
+      }),
+    );
+
+    renderWithAuthenticatedProviders(<TransactionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$150.00')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Previous' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('pagination hidden when totalPages <= 1', async () => {
+    renderWithAuthenticatedProviders(<TransactionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$150.00')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Previous' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Next' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
+import { PaginatedResponse } from '@my-pocket/shared';
 import { useAuth } from '@/contexts/AuthContext';
-import { transactionsApi } from '@/lib/transactions';
+import { transactionsApi, GetTransactionsParams } from '@/lib/transactions';
 import { categoriesApi } from '@/lib/categories';
 import { Transaction, Category, TransactionType } from '@/types';
 import { AuthLayout } from '@/components/layouts/AuthLayout';
 import { TransactionsTableSkeleton } from '@/components/TransactionsTableSkeleton';
+import { Pagination } from '@/components/Pagination';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -43,14 +45,9 @@ import { formatCurrencyFromString, formatDateUTC } from '@/lib/formatters';
 type FilterType = 'ALL' | TransactionType;
 type FilterCategory = 'ALL' | string;
 
-function parseFilterDate(dateString: string): Date | null {
-  if (!dateString) return null;
-  const date = new Date(dateString);
-  return isNaN(date.getTime()) ? null : date;
-}
-
 export default function TransactionsPage() {
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [transactions, setTransactions] =
+    useState<PaginatedResponse<Transaction> | null>(null);
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deleteTransaction, setDeleteTransaction] =
@@ -60,41 +57,12 @@ export default function TransactionsPage() {
   const [filterEndDate, setFilterEndDate] = useState<string>('');
   const [filterType, setFilterType] = useState<FilterType>('ALL');
   const [filterCategory, setFilterCategory] = useState<FilterCategory>('ALL');
+  const [currentPage, setCurrentPage] = useState(1);
   const { isAuthenticated, logout } = useAuth();
   const router = useRouter();
   const t = useTranslations('transactions');
   const tCommon = useTranslations('common');
   const locale = useLocale();
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      loadData();
-    }
-  }, [isAuthenticated]);
-
-  const loadData = async () => {
-    try {
-      const [transactionsData, categoriesData] = await Promise.all([
-        transactionsApi.getAll(),
-        categoriesApi.getAll(),
-      ]);
-      setTransactions(transactionsData);
-      setCategories(categoriesData);
-    } catch (error) {
-      if (error instanceof ApiException) {
-        if (error.statusCode === 401) {
-          logout();
-          router.push('/login');
-          return;
-        }
-        toast.error(error.message);
-      } else {
-        toast.error(t('failedToLoad'));
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const categoryMap = useMemo(() => {
     return categories.reduce(
@@ -106,40 +74,84 @@ export default function TransactionsPage() {
     );
   }, [categories]);
 
-  const filteredTransactions = useMemo(() => {
-    const startDate = parseFilterDate(filterStartDate);
-    const endDate = parseFilterDate(filterEndDate);
+  useEffect(() => {
+    if (!isAuthenticated) return;
 
-    return transactions.filter((transaction) => {
-      const transactionDate = new Date(transaction.date);
+    let cancelled = false;
 
-      const matchesStartDate = !startDate || transactionDate >= startDate;
-      const matchesEndDate =
-        !endDate ||
-        transactionDate <=
-          new Date(endDate.getTime() + 24 * 60 * 60 * 1000 - 1);
-      const matchesType =
-        filterType === 'ALL' || transaction.type === filterType;
-      const matchesCategory =
-        filterCategory === 'ALL' || transaction.categoryId === filterCategory;
+    const loadData = async () => {
+      setIsLoading(true);
+      try {
+        const params: GetTransactionsParams = { page: currentPage, limit: 20 };
+        if (filterType !== 'ALL') params.type = filterType;
+        if (filterCategory !== 'ALL') params.categoryId = filterCategory;
+        if (filterStartDate) params.startDate = filterStartDate;
+        if (filterEndDate) params.endDate = filterEndDate;
 
-      return (
-        matchesStartDate && matchesEndDate && matchesType && matchesCategory
-      );
-    });
+        const [transactionsData, categoriesData] = await Promise.all([
+          transactionsApi.getAll(params),
+          categoriesApi.getAll(),
+        ]);
+        if (!cancelled) {
+          setTransactions(transactionsData);
+          setCategories(categoriesData);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        if (error instanceof ApiException) {
+          if (error.statusCode === 401) {
+            logout();
+            router.push('/login');
+            return;
+          }
+          toast.error(error.message);
+        } else {
+          toast.error(t('failedToLoad'));
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    loadData();
+    return () => {
+      cancelled = true;
+    };
   }, [
-    transactions,
-    filterStartDate,
-    filterEndDate,
+    isAuthenticated,
+    currentPage,
     filterType,
     filterCategory,
-  ]);
+    filterStartDate,
+    filterEndDate,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleFilterTypeChange = (value: FilterType) => {
+    setFilterType(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterCategoryChange = (value: FilterCategory) => {
+    setFilterCategory(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterStartDateChange = (value: string) => {
+    setFilterStartDate(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterEndDateChange = (value: string) => {
+    setFilterEndDate(value);
+    setCurrentPage(1);
+  };
 
   const clearFilters = () => {
     setFilterStartDate('');
     setFilterEndDate('');
     setFilterType('ALL');
     setFilterCategory('ALL');
+    setCurrentPage(1);
   };
 
   const handleDelete = async () => {
@@ -148,9 +160,23 @@ export default function TransactionsPage() {
     setIsDeleting(true);
     try {
       await transactionsApi.delete(deleteTransaction.id);
-      setTransactions((prev) =>
-        prev.filter((t) => t.id !== deleteTransaction.id),
-      );
+      setTransactions((prev) => {
+        if (!prev) return prev;
+        const newData = prev.data.filter((t) => t.id !== deleteTransaction.id);
+        const newTotal = prev.total - 1;
+        const newTotalPages = Math.ceil(newTotal / prev.limit);
+        // If current page becomes empty and we're not on page 1, go back
+        if (newData.length === 0 && currentPage > 1) {
+          setCurrentPage((p) => p - 1);
+          return prev;
+        }
+        return {
+          ...prev,
+          data: newData,
+          total: newTotal,
+          totalPages: newTotalPages,
+        };
+      });
       toast.success(t('deleteSuccess'));
       setDeleteTransaction(null);
     } catch (error) {
@@ -180,7 +206,7 @@ export default function TransactionsPage() {
             id="start-date"
             type="date"
             value={filterStartDate}
-            onChange={(e) => setFilterStartDate(e.target.value)}
+            onChange={(e) => handleFilterStartDateChange(e.target.value)}
             className="w-[150px]"
           />
         </div>
@@ -191,14 +217,14 @@ export default function TransactionsPage() {
             id="end-date"
             type="date"
             value={filterEndDate}
-            onChange={(e) => setFilterEndDate(e.target.value)}
+            onChange={(e) => handleFilterEndDateChange(e.target.value)}
             className="w-[150px]"
           />
         </div>
 
         <Select
           value={filterType}
-          onValueChange={(value) => setFilterType(value as FilterType)}
+          onValueChange={(value) => handleFilterTypeChange(value as FilterType)}
         >
           <SelectTrigger className="w-[150px]" data-testid="type-filter">
             <SelectValue placeholder={tCommon('filterByType')} />
@@ -212,7 +238,9 @@ export default function TransactionsPage() {
 
         <Select
           value={filterCategory}
-          onValueChange={(value) => setFilterCategory(value as FilterCategory)}
+          onValueChange={(value) =>
+            handleFilterCategoryChange(value as FilterCategory)
+          }
         >
           <SelectTrigger className="w-[180px]" data-testid="category-filter">
             <SelectValue placeholder={tCommon('filterByCategory')} />
@@ -235,11 +263,11 @@ export default function TransactionsPage() {
       <div className="bg-card rounded-lg shadow">
         {isLoading ? (
           <TransactionsTableSkeleton />
-        ) : transactions.length === 0 ? (
+        ) : transactions?.data.length === 0 && transactions?.total === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
             {t('noTransactions')}
           </div>
-        ) : filteredTransactions.length === 0 ? (
+        ) : transactions?.data.length === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
             {t('noMatch')}
           </div>
@@ -261,7 +289,7 @@ export default function TransactionsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredTransactions.map((transaction) => (
+                {transactions?.data.map((transaction) => (
                   <TableRow key={transaction.id}>
                     <TableCell className="text-muted-foreground">
                       {formatDateUTC(transaction.date, locale)}
@@ -310,6 +338,15 @@ export default function TransactionsPage() {
           </div>
         )}
       </div>
+
+      {transactions && (
+        <Pagination
+          page={transactions.page}
+          totalPages={transactions.totalPages}
+          onPageChange={setCurrentPage}
+          disabled={isLoading}
+        />
+      )}
 
       <Dialog
         open={!!deleteTransaction}

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
-import { PaginatedResponse } from '@my-pocket/shared';
+import { PaginatedResponse } from '@/lib/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { transactionsApi, GetTransactionsParams } from '@/lib/transactions';
 import { categoriesApi } from '@/lib/categories';

--- a/apps/web/src/components/Pagination.test.tsx
+++ b/apps/web/src/components/Pagination.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders, setupUser } from '@/test/test-utils';
+import { Pagination } from './Pagination';
+
+describe('Pagination', () => {
+  it('returns null when totalPages <= 1', () => {
+    const { container } = renderWithProviders(
+      <Pagination page={1} totalPages={1} onPageChange={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when totalPages is 0', () => {
+    const { container } = renderWithProviders(
+      <Pagination page={1} totalPages={0} onPageChange={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders Previous and Next buttons when totalPages > 1', () => {
+    renderWithProviders(
+      <Pagination page={1} totalPages={3} onPageChange={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Previous' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+  });
+
+  it('shows correct page info text', () => {
+    renderWithProviders(
+      <Pagination page={2} totalPages={5} onPageChange={vi.fn()} />,
+    );
+    expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+  });
+
+  it('Previous button is disabled on page 1', () => {
+    renderWithProviders(
+      <Pagination page={1} totalPages={3} onPageChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+  });
+
+  it('Next button is disabled on last page', () => {
+    renderWithProviders(
+      <Pagination page={3} totalPages={3} onPageChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('Previous button is enabled when not on first page', () => {
+    renderWithProviders(
+      <Pagination page={2} totalPages={3} onPageChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Previous' })).not.toBeDisabled();
+  });
+
+  it('Next button is enabled when not on last page', () => {
+    renderWithProviders(
+      <Pagination page={2} totalPages={3} onPageChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled();
+  });
+
+  it('calls onPageChange with page - 1 when Previous is clicked', async () => {
+    const user = setupUser();
+    const onPageChange = vi.fn();
+    renderWithProviders(
+      <Pagination page={3} totalPages={5} onPageChange={onPageChange} />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onPageChange with page + 1 when Next is clicked', async () => {
+    const user = setupUser();
+    const onPageChange = vi.fn();
+    renderWithProviders(
+      <Pagination page={3} totalPages={5} onPageChange={onPageChange} />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it('both buttons are disabled when disabled prop is true', () => {
+    renderWithProviders(
+      <Pagination page={2} totalPages={5} onPageChange={vi.fn()} disabled />,
+    );
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  disabled?: boolean;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  disabled,
+}: PaginationProps) {
+  const t = useTranslations('pagination');
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-4 mt-4">
+      <Button
+        variant="outline"
+        onClick={() => onPageChange(page - 1)}
+        disabled={disabled || page <= 1}
+      >
+        {t('previous')}
+      </Button>
+      <span className="text-sm text-muted-foreground">
+        {t('pageOf', { page, totalPages })}
+      </span>
+      <Button
+        variant="outline"
+        onClick={() => onPageChange(page + 1)}
+        disabled={disabled || page >= totalPages}
+      >
+        {t('next')}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/budgets.test.ts
+++ b/apps/web/src/lib/budgets.test.ts
@@ -13,14 +13,19 @@ describe('budgetsApi', () => {
     it('should fetch all budgets', async () => {
       const result = await budgetsApi.getAll();
 
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toHaveProperty('id');
-      expect(result[0]).toHaveProperty('amount');
-      expect(result[0]).toHaveProperty('categoryId');
-      expect(result[0]).toHaveProperty('month');
-      expect(result[0]).toHaveProperty('year');
-      expect(result[0]).toHaveProperty('type');
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('page');
+      expect(result).toHaveProperty('limit');
+      expect(result).toHaveProperty('totalPages');
+      expect(Array.isArray(result.data)).toBe(true);
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(result.data[0]).toHaveProperty('id');
+      expect(result.data[0]).toHaveProperty('amount');
+      expect(result.data[0]).toHaveProperty('categoryId');
+      expect(result.data[0]).toHaveProperty('month');
+      expect(result.data[0]).toHaveProperty('year');
+      expect(result.data[0]).toHaveProperty('type');
     });
 
     it('should throw ApiException on 401', async () => {

--- a/apps/web/src/lib/budgets.ts
+++ b/apps/web/src/lib/budgets.ts
@@ -1,5 +1,5 @@
 import { api } from '@/lib/api';
-import { PaginatedResponse } from '@my-pocket/shared';
+import { PaginatedResponse } from '@/lib/types';
 import {
   Budget,
   BatchBudgetResponse,

--- a/apps/web/src/lib/budgets.ts
+++ b/apps/web/src/lib/budgets.ts
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api';
+import { PaginatedResponse } from '@my-pocket/shared';
 import {
   Budget,
   BatchBudgetResponse,
@@ -9,8 +10,29 @@ import {
   UpdateBudgetDto,
 } from '@/types';
 
+export interface GetBudgetsParams {
+  page?: number;
+  limit?: number;
+  month?: number;
+  year?: number;
+  type?: string;
+}
+
 export const budgetsApi = {
-  getAll: () => api.get<Budget[]>('/budgets'),
+  getAll: (params?: GetBudgetsParams) => {
+    const searchParams = new URLSearchParams();
+    if (params?.page !== undefined)
+      searchParams.set('page', String(params.page));
+    if (params?.limit !== undefined)
+      searchParams.set('limit', String(params.limit));
+    if (params?.month !== undefined)
+      searchParams.set('month', String(params.month));
+    if (params?.year !== undefined)
+      searchParams.set('year', String(params.year));
+    if (params?.type) searchParams.set('type', params.type);
+    const qs = searchParams.toString();
+    return api.get<PaginatedResponse<Budget>>(`/budgets${qs ? `?${qs}` : ''}`);
+  },
 
   getById: (id: string) => api.get<Budget>(`/budgets/${id}`),
 

--- a/apps/web/src/lib/transactions.test.ts
+++ b/apps/web/src/lib/transactions.test.ts
@@ -13,13 +13,18 @@ describe('transactionsApi', () => {
     it('should fetch all transactions', async () => {
       const result = await transactionsApi.getAll();
 
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toHaveProperty('id');
-      expect(result[0]).toHaveProperty('amount');
-      expect(result[0]).toHaveProperty('type');
-      expect(result[0]).toHaveProperty('categoryId');
-      expect(result[0]).toHaveProperty('date');
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('page');
+      expect(result).toHaveProperty('limit');
+      expect(result).toHaveProperty('totalPages');
+      expect(Array.isArray(result.data)).toBe(true);
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(result.data[0]).toHaveProperty('id');
+      expect(result.data[0]).toHaveProperty('amount');
+      expect(result.data[0]).toHaveProperty('type');
+      expect(result.data[0]).toHaveProperty('categoryId');
+      expect(result.data[0]).toHaveProperty('date');
     });
 
     it('should throw ApiException on 401', async () => {

--- a/apps/web/src/lib/transactions.ts
+++ b/apps/web/src/lib/transactions.ts
@@ -1,5 +1,5 @@
 import { api } from '@/lib/api';
-import { PaginatedResponse } from '@my-pocket/shared';
+import { PaginatedResponse } from '@/lib/types';
 import {
   Transaction,
   CreateTransactionDto,

--- a/apps/web/src/lib/transactions.ts
+++ b/apps/web/src/lib/transactions.ts
@@ -1,12 +1,36 @@
 import { api } from '@/lib/api';
+import { PaginatedResponse } from '@my-pocket/shared';
 import {
   Transaction,
   CreateTransactionDto,
   UpdateTransactionDto,
 } from '@/types';
 
+export interface GetTransactionsParams {
+  page?: number;
+  limit?: number;
+  type?: string;
+  categoryId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
 export const transactionsApi = {
-  getAll: () => api.get<Transaction[]>('/transactions'),
+  getAll: (params?: GetTransactionsParams) => {
+    const searchParams = new URLSearchParams();
+    if (params?.page !== undefined)
+      searchParams.set('page', String(params.page));
+    if (params?.limit !== undefined)
+      searchParams.set('limit', String(params.limit));
+    if (params?.type) searchParams.set('type', params.type);
+    if (params?.categoryId) searchParams.set('categoryId', params.categoryId);
+    if (params?.startDate) searchParams.set('startDate', params.startDate);
+    if (params?.endDate) searchParams.set('endDate', params.endDate);
+    const qs = searchParams.toString();
+    return api.get<PaginatedResponse<Transaction>>(
+      `/transactions${qs ? `?${qs}` : ''}`,
+    );
+  },
 
   getById: (id: string) => api.get<Transaction>(`/transactions/${id}`),
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -454,7 +454,33 @@ export const handlers = [
         { status: 401 },
       );
     }
-    return HttpResponse.json(mockBudgets);
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') ?? '1');
+    const limit = parseInt(url.searchParams.get('limit') ?? '20');
+    const month = url.searchParams.get('month')
+      ? parseInt(url.searchParams.get('month')!)
+      : undefined;
+    const year = url.searchParams.get('year')
+      ? parseInt(url.searchParams.get('year')!)
+      : undefined;
+    const type = url.searchParams.get('type') ?? undefined;
+
+    let filtered = [...mockBudgets];
+    if (month !== undefined)
+      filtered = filtered.filter((b) => b.month === month);
+    if (year !== undefined) filtered = filtered.filter((b) => b.year === year);
+    if (type) filtered = filtered.filter((b) => b.type === type);
+
+    const total = filtered.length;
+    const skip = (page - 1) * limit;
+    const data = filtered.slice(skip, skip + limit);
+    return HttpResponse.json({
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    });
   }),
 
   http.get(`${API_URL}/budgets/:id`, ({ params, request }) => {
@@ -756,7 +782,37 @@ export const handlers = [
         { status: 401 },
       );
     }
-    return HttpResponse.json(mockTransactions);
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') ?? '1');
+    const limit = parseInt(url.searchParams.get('limit') ?? '20');
+    const type = url.searchParams.get('type') ?? undefined;
+    const categoryId = url.searchParams.get('categoryId') ?? undefined;
+    const startDate = url.searchParams.get('startDate') ?? undefined;
+    const endDate = url.searchParams.get('endDate') ?? undefined;
+
+    let filtered = [...mockTransactions];
+    if (type) filtered = filtered.filter((t) => t.type === type);
+    if (categoryId)
+      filtered = filtered.filter((t) => t.categoryId === categoryId);
+    if (startDate) {
+      const start = new Date(startDate);
+      filtered = filtered.filter((t) => new Date(t.date) >= start);
+    }
+    if (endDate) {
+      const end = new Date(`${endDate.slice(0, 10)}T23:59:59.999Z`);
+      filtered = filtered.filter((t) => new Date(t.date) <= end);
+    }
+
+    const total = filtered.length;
+    const skip = (page - 1) * limit;
+    const data = filtered.slice(skip, skip + limit);
+    return HttpResponse.json({
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    });
   }),
 
   http.get(`${API_URL}/transactions/:id`, ({ params, request }) => {


### PR DESCRIPTION
Implement server-side pagination (default 20 items/page) for GET /transactions
and GET /budgets endpoints across the full stack:

- Backend: add GetTransactionsQueryDto and GetBudgetsQueryDto with page/limit
  and filter params; update services to use Prisma skip/take + count; update
  controllers, swagger decorators, and unit tests
- Frontend: update transactions.ts and budgets.ts lib helpers to accept
  GetTransactionsParams/GetBudgetsParams and return PaginatedResponse<T>;
  add Pagination component with i18n support; rewrite transactions and budgets
  pages to use server-side pagination with filter-driven page reset; update
  MSW handlers and all affected tests