### PR TITLE
feat(web): add landing page with hero, features, and CTA sections

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -45,7 +45,26 @@
   "home": {
     "tagline": "Personal Finance Management",
     "signIn": "Sign in",
-    "getStarted": "Get Started"
+    "getStarted": "Get Started",
+    "headline": "When you don't know where your money goes, how can you expect to make more?",
+    "subheadline": "The first step for great gains is being fully aware of your actual financial situation.",
+    "features": {
+      "track": {
+        "title": "Track Every Transaction",
+        "description": "Know exactly where every cent goes. Log income and expenses in seconds."
+      },
+      "budgets": {
+        "title": "Set Smart Budgets",
+        "description": "Plan ahead by category. Set monthly targets and stay in control of your spending."
+      },
+      "insights": {
+        "title": "Visualize Your Progress",
+        "description": "Clear charts and reports give you a complete picture of your financial health."
+      }
+    },
+    "ctaTitle": "Start taking control today",
+    "ctaSubtitle": "Awareness is the foundation of every great financial decision.",
+    "ctaButton": "Get Started Free"
   },
   "auth": {
     "welcomeBack": "Welcome back",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -45,7 +45,26 @@
   "home": {
     "tagline": "Gestão de Finanças Pessoais",
     "signIn": "Entrar",
-    "getStarted": "Começar"
+    "getStarted": "Começar",
+    "headline": "Quando você não sabe para onde seu dinheiro vai, como pode esperar ganhar mais?",
+    "subheadline": "O primeiro passo para grandes conquistas é ter plena consciência da sua situação financeira atual.",
+    "features": {
+      "track": {
+        "title": "Registre Cada Transação",
+        "description": "Saiba exatamente para onde vai cada centavo. Registre receitas e despesas em segundos."
+      },
+      "budgets": {
+        "title": "Defina Orçamentos Inteligentes",
+        "description": "Planeje por categoria. Estabeleça metas mensais e mantenha o controle dos seus gastos."
+      },
+      "insights": {
+        "title": "Visualize Seu Progresso",
+        "description": "Gráficos e relatórios claros te dão uma visão completa da sua saúde financeira."
+      }
+    },
+    "ctaTitle": "Comece a tomar o controle hoje",
+    "ctaSubtitle": "A consciência é a base de toda grande decisão financeira.",
+    "ctaButton": "Começar Gratuitamente"
   },
   "auth": {
     "welcomeBack": "Bem-vindo de volta",

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/test-utils';
+import HomePage from './page';
+
+// Mock next/navigation
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', async () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('@/contexts/AuthContext', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/contexts/AuthContext')>();
+  return {
+    ...actual,
+    useAuth: () => mockUseAuth(),
+  };
+});
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state when isLoading is true', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+
+    renderWithProviders(<HomePage />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('redirects to /dashboard when authenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('renders hero headline for unauthenticated users', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    expect(
+      screen.getByText(
+        "When you don't know where your money goes, how can you expect to make more?",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The first step for great gains is being fully aware of your actual financial situation.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders all three feature cards', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    expect(screen.getByText('Track Every Transaction')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Know exactly where every cent goes. Log income and expenses in seconds.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Set Smart Budgets')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Plan ahead by category. Set monthly targets and stay in control of your spending.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Visualize Your Progress')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Clear charts and reports give you a complete picture of your financial health.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders CTA section with button', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    expect(screen.getByText('Start taking control today')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Awareness is the foundation of every great financial decision.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Get Started Free' }),
+    ).toHaveAttribute('href', '/register');
+  });
+
+  it('Sign In link points to /login', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/login',
+    );
+  });
+
+  it('Get Started link in hero points to /register', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderWithProviders(<HomePage />);
+
+    const getStartedLinks = screen.getAllByRole('link', {
+      name: /get started/i,
+    });
+    expect(
+      getStartedLinks.every(
+        (link) => link.getAttribute('href') === '/register',
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,8 +4,10 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
+import { TrendingUp, Target, BarChart3 } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export default function Home() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -28,11 +30,19 @@ export default function Home() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24 bg-background">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">My Pocket</h1>
-        <p className="text-lg text-muted-foreground mb-8">{t('tagline')}</p>
-        <div className="flex gap-4 justify-center">
+    <main className="flex min-h-screen flex-col bg-background">
+      {/* Hero Section */}
+      <section className="flex flex-1 flex-col items-center justify-center px-6 py-24 text-center">
+        <span className="mb-6 inline-block rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+          My Pocket
+        </span>
+        <h1 className="mb-6 max-w-3xl text-4xl font-bold leading-tight tracking-tight sm:text-5xl lg:text-6xl">
+          {t('headline')}
+        </h1>
+        <p className="mb-10 max-w-xl text-lg text-muted-foreground">
+          {t('subheadline')}
+        </p>
+        <div className="flex flex-wrap gap-4 justify-center">
           <Link href="/login">
             <Button variant="outline" size="lg">
               {t('signIn')}
@@ -42,7 +52,57 @@ export default function Home() {
             <Button size="lg">{t('getStarted')}</Button>
           </Link>
         </div>
-      </div>
+      </section>
+
+      {/* Features Section */}
+      <section className="px-6 py-20">
+        <div className="mx-auto grid max-w-5xl gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <Card>
+            <CardHeader>
+              <TrendingUp className="mb-2 h-8 w-8 text-primary" />
+              <CardTitle>{t('features.track.title')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">
+                {t('features.track.description')}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <Target className="mb-2 h-8 w-8 text-primary" />
+              <CardTitle>{t('features.budgets.title')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">
+                {t('features.budgets.description')}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <BarChart3 className="mb-2 h-8 w-8 text-primary" />
+              <CardTitle>{t('features.insights.title')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">
+                {t('features.insights.description')}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="bg-muted px-6 py-20 text-center">
+        <h2 className="mb-4 text-3xl font-bold">{t('ctaTitle')}</h2>
+        <p className="mb-8 text-lg text-muted-foreground">{t('ctaSubtitle')}</p>
+        <Link href="/register">
+          <Button size="lg">{t('ctaButton')}</Button>
+        </Link>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
Replaces the minimal placeholder with a full landing page communicating the app's value proposition. Adds i18n keys for all new content in both en and pt-BR, and covers the page with 7 unit tests.