### PR TITLE
feat(budgets): add optional description field

### DIFF
--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -20,6 +20,7 @@ import { PrismaService } from '../shared/prisma.service';
 type BudgetRecord = {
   id: string;
   amount: number;
+  description: string | null;
   categoryId: string;
   userId: string;
   month: number;
@@ -307,6 +308,7 @@ describe('BudgetService', () => {
       expect(result).toEqual({
         ...createDto,
         amount: '500.00',
+        description: null,
         id: result.id,
         type: BudgetType.EXPENSE,
       });
@@ -411,6 +413,33 @@ describe('BudgetService', () => {
       expect(result1.id).not.toBe(result2.id);
       expect((await service.getAllBudgets(userId)).data).toHaveLength(2);
     });
+
+    it('should create a budget with a description', async () => {
+      const createDto: CreateBudgetDto = {
+        amount: 500,
+        categoryId,
+        month: 1,
+        year: 2026,
+        description: 'Monthly grocery target',
+      };
+
+      const result = await service.createBudget(createDto, userId);
+
+      expect(result.description).toBe('Monthly grocery target');
+    });
+
+    it('should set description to null when not provided', async () => {
+      const createDto: CreateBudgetDto = {
+        amount: 500,
+        categoryId,
+        month: 1,
+        year: 2026,
+      };
+
+      const result = await service.createBudget(createDto, userId);
+
+      expect(result.description).toBeNull();
+    });
   });
 
   describe('updateBudget', () => {
@@ -435,6 +464,7 @@ describe('BudgetService', () => {
       expect(result).toEqual({
         id: budget.id,
         amount: '700.00',
+        description: null,
         categoryId,
         month: 1,
         year: 2026,
@@ -490,6 +520,35 @@ describe('BudgetService', () => {
       ).rejects.toThrow('budgets.errors.categoryNotFound');
     });
 
+    it('should update budget description', async () => {
+      const [budget] = (await service.getAllBudgets(userId)).data;
+      const result = await service.updateBudget(
+        budget.id,
+        { description: 'New note' },
+        userId,
+      );
+
+      expect(result.description).toBe('New note');
+    });
+
+    it('should clear budget description when null is passed', async () => {
+      const [budget] = (await service.getAllBudgets(userId)).data;
+      // First set a description
+      await service.updateBudget(
+        budget.id,
+        { description: 'Some note' },
+        userId,
+      );
+      // Then clear it
+      const result = await service.updateBudget(
+        budget.id,
+        { description: null },
+        userId,
+      );
+
+      expect(result.description).toBeNull();
+    });
+
     it('should allow budget to update itself without duplicate error', async () => {
       const updateDto: UpdateBudgetDto = {
         amount: 800,
@@ -503,6 +562,7 @@ describe('BudgetService', () => {
       expect(result).toEqual({
         id: budget.id,
         amount: '800.00',
+        description: null,
         categoryId,
         month: 1,
         year: 2026,
@@ -934,6 +994,7 @@ describe('BudgetService', () => {
       expect(result).toEqual({
         id: budget.id,
         amount: '500.00',
+        description: null,
         categoryId,
         month: 1,
         year: 2026,
@@ -1011,6 +1072,7 @@ describe('BudgetService', () => {
       expect(result).toEqual({
         id: budget.id,
         amount: '500.00',
+        description: null,
         categoryId,
         month: 1,
         year: 2026,

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -43,6 +43,7 @@ type BudgetWithSpending = BudgetWithSpendingExpense | BudgetWithSpendingIncome;
 type BudgetBase = {
   id: string;
   amount: string;
+  description: string | null;
   categoryId: string;
   month: number;
   year: number;
@@ -108,6 +109,7 @@ export class BudgetService {
   private readonly budgetSelect = {
     id: true,
     amount: true,
+    description: true,
     categoryId: true,
     month: true,
     year: true,
@@ -127,6 +129,7 @@ export class BudgetService {
   private mapBudget(budget: {
     id: string;
     amount: { toString(): string };
+    description: string | null;
     categoryId: string;
     month: number;
     year: number;
@@ -294,6 +297,7 @@ export class BudgetService {
       const newBudget = await this.prisma.budget.create({
         data: {
           amount: budgetData.amount,
+          description: budgetData.description ?? null,
           categoryId: budgetData.categoryId,
           month: budgetData.month,
           year: budgetData.year,
@@ -443,6 +447,7 @@ export class BudgetService {
         where: { id },
         data: {
           amount: budgetData.amount,
+          description: budgetData.description,
           categoryId: budgetData.categoryId,
           month: budgetData.month,
           year: budgetData.year,

--- a/apps/api/src/modules/budgets/dto/budget-with-spending.dto.ts
+++ b/apps/api/src/modules/budgets/dto/budget-with-spending.dto.ts
@@ -16,6 +16,14 @@ export class BudgetWithSpendingDto {
   amount: string;
 
   @ApiProperty({
+    description: 'Optional notes about the budget',
+    example: 'Monthly grocery target',
+    required: false,
+    nullable: true,
+  })
+  description: string | null;
+
+  @ApiProperty({
     description: 'Category UUID',
     example: '123e4567-e89b-12d3-a456-426614174001',
   })

--- a/apps/api/src/modules/budgets/dto/budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/budget.dto.ts
@@ -16,6 +16,14 @@ export class BudgetDto {
   amount: string;
 
   @ApiProperty({
+    description: 'Optional notes about the budget',
+    example: 'Monthly grocery target',
+    required: false,
+    nullable: true,
+  })
+  description: string | null;
+
+  @ApiProperty({
     description: 'Category UUID',
     example: '123e4567-e89b-12d3-a456-426614174001',
   })

--- a/apps/api/src/modules/budgets/dto/create-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/create-budget.dto.ts
@@ -1,4 +1,10 @@
-import { IsNumber, IsUUID } from 'class-validator';
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateBudgetDto {
@@ -32,4 +38,14 @@ export class CreateBudgetDto {
   })
   @IsNumber()
   year: number;
+
+  @ApiProperty({
+    description: 'Optional notes about the budget',
+    example: 'Monthly grocery target',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
 }

--- a/apps/api/src/modules/budgets/dto/update-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/update-budget.dto.ts
@@ -1,4 +1,10 @@
-import { IsNumber, IsOptional, IsUUID } from 'class-validator';
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateBudgetDto {
@@ -39,4 +45,15 @@ export class UpdateBudgetDto {
   @IsOptional()
   @IsNumber()
   year?: number;
+
+  @ApiProperty({
+    description: 'Optional notes about the budget',
+    example: 'Monthly grocery target',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string | null;
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -286,7 +286,8 @@
     "endMonthRequired": "End month is required",
     "endYearRequired": "End year is required",
     "endDateBeforeStart": "End date must be after or equal to start date",
-    "batchCreateSuccess": "{created} budgets created ({skipped} skipped)"
+    "batchCreateSuccess": "{created} budgets created ({skipped} skipped)",
+    "descriptionPlaceholder": "e.g., Monthly grocery target"
   },
   "budgetDetails": {
     "budgetAmount": "Budget Amount",
@@ -300,7 +301,8 @@
     "transactionsFor": "Transactions in {categoryName} for {period}",
     "noTransactions": "No transactions found for this budget period.",
     "unknownCategory": "Unknown Category",
-    "noDescriptionLabel": "No description"
+    "noDescriptionLabel": "No description",
+    "description": "Description"
   },
   "errorBoundary": {
     "title": "Something went wrong",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -286,7 +286,8 @@
     "endMonthRequired": "Mês de término é obrigatório",
     "endYearRequired": "Ano de término é obrigatório",
     "endDateBeforeStart": "A data de término deve ser igual ou posterior à data de início",
-    "batchCreateSuccess": "{created} orçamentos criados ({skipped} ignorados)"
+    "batchCreateSuccess": "{created} orçamentos criados ({skipped} ignorados)",
+    "descriptionPlaceholder": "ex.: Meta mensal de supermercado"
   },
   "budgetDetails": {
     "budgetAmount": "Valor do Orçamento",
@@ -300,7 +301,8 @@
     "transactionsFor": "Transações em {categoryName} para {period}",
     "noTransactions": "Nenhuma transação encontrada para este período de orçamento.",
     "unknownCategory": "Categoria Desconhecida",
-    "noDescriptionLabel": "Sem descrição"
+    "noDescriptionLabel": "Sem descrição",
+    "description": "Descrição"
   },
   "errorBoundary": {
     "title": "Algo deu errado",

--- a/apps/web/src/app/budgets/[id]/edit/page.tsx
+++ b/apps/web/src/app/budgets/[id]/edit/page.tsx
@@ -71,6 +71,7 @@ export default function EditBudgetPage() {
               categoryId: budget.categoryId,
               month: budget.month,
               year: budget.year,
+              description: budget.description,
             }}
             onSubmit={handleUpdate}
           />

--- a/apps/web/src/components/BudgetDetails.test.tsx
+++ b/apps/web/src/components/BudgetDetails.test.tsx
@@ -22,6 +22,7 @@ vi.mock('next/navigation', () => ({
 const mockExpenseBudget: BudgetWithDetailsExpense = {
   id: 'budget-1',
   amount: '500.00',
+  description: null,
   categoryId: 'cat-1',
   month: 3,
   year: 2026,
@@ -42,6 +43,7 @@ const mockExpenseBudget: BudgetWithDetailsExpense = {
 const mockIncomeBudget: BudgetWithDetailsIncome = {
   id: 'budget-2',
   amount: '2000.00',
+  description: null,
   categoryId: 'cat-2',
   month: 3,
   year: 2026,
@@ -320,6 +322,26 @@ describe('BudgetDetails', () => {
 
       const backLink = screen.getByRole('link', { name: 'Back to Budgets' });
       expect(backLink).toHaveAttribute('href', '/budgets');
+    });
+  });
+
+  describe('description', () => {
+    it('should display description when present', () => {
+      const budgetWithDesc: BudgetWithDetailsExpense = {
+        ...mockExpenseBudget,
+        description: 'Monthly grocery target',
+      };
+
+      renderWithProviders(<BudgetDetails budget={budgetWithDesc} />);
+
+      expect(screen.getByText('Description')).toBeInTheDocument();
+      expect(screen.getByText('Monthly grocery target')).toBeInTheDocument();
+    });
+
+    it('should not display description section when null', () => {
+      renderWithProviders(<BudgetDetails budget={mockExpenseBudget} />);
+
+      expect(screen.queryByText('Description')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/BudgetDetails.tsx
+++ b/apps/web/src/components/BudgetDetails.tsx
@@ -115,6 +115,16 @@ export function BudgetDetails({ budget }: BudgetDetailsProps) {
             </p>
           </div>
 
+          {/* Description */}
+          {budget.description && (
+            <div>
+              <p className="text-sm text-muted-foreground">
+                {t('description')}
+              </p>
+              <p className="text-sm">{budget.description}</p>
+            </div>
+          )}
+
           {/* Progress Bar */}
           <div className="space-y-2">
             <div className="flex justify-between text-sm">

--- a/apps/web/src/components/BudgetForm.test.tsx
+++ b/apps/web/src/components/BudgetForm.test.tsx
@@ -82,6 +82,7 @@ describe('BudgetForm', () => {
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
     expect(screen.getByLabelText('Month')).toBeInTheDocument();
     expect(screen.getByLabelText('Year')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
   });
 
   it('should load categories in dropdown', async () => {
@@ -131,6 +132,27 @@ describe('BudgetForm', () => {
       expect(screen.getByDisplayValue('$500.00')).toBeInTheDocument();
       expect(screen.getByDisplayValue('2026')).toBeInTheDocument();
     });
+  });
+
+  it('should render form with initial description', async () => {
+    renderWithProviders(
+      <BudgetForm
+        title="Edit Budget"
+        submitLabel="Save"
+        initialData={{
+          amount: 500,
+          categoryId: 'cat-2',
+          month: 3,
+          year: 2026,
+          description: 'Monthly grocery target',
+        }}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    expect(
+      screen.getByDisplayValue('Monthly grocery target'),
+    ).toBeInTheDocument();
   });
 
   it('should have required attribute on amount and year inputs', () => {
@@ -193,6 +215,7 @@ describe('BudgetForm', () => {
         categoryId: 'cat-2',
         month: 3,
         year: 2026,
+        description: undefined,
       });
     });
 
@@ -317,6 +340,31 @@ describe('BudgetForm', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(mockRouterPush).toHaveBeenCalledWith('/budgets');
+  });
+
+  it('should include description in submission when provided', async () => {
+    renderWithProviders(
+      <BudgetForm
+        title="Create Budget"
+        submitLabel="Create"
+        initialData={{
+          amount: 500,
+          categoryId: 'cat-2',
+          month: 3,
+          year: 2026,
+          description: 'Monthly grocery target',
+        }}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Monthly grocery target' }),
+      );
+    });
   });
 
   it('should validate amount is positive', async () => {

--- a/apps/web/src/components/BudgetForm.tsx
+++ b/apps/web/src/components/BudgetForm.tsx
@@ -7,6 +7,7 @@ import CurrencyInput from 'react-currency-input-field';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -33,6 +34,7 @@ interface BudgetFormProps {
     categoryId: string;
     month: number;
     year: number;
+    description?: string | null;
   };
   onSubmit: (data: CreateBudgetDto) => Promise<unknown>;
   title: string;
@@ -62,6 +64,9 @@ export function BudgetForm({
   const [endMonth, setEndMonth] = useState<number | ''>('');
   const [endYear, setEndYear] = useState<string>(
     new Date().getFullYear().toString(),
+  );
+  const [description, setDescription] = useState<string>(
+    initialData?.description ?? '',
   );
   const [isLoading, setIsLoading] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -177,6 +182,7 @@ export function BudgetForm({
         categoryId,
         month: month as number,
         year: yearNum,
+        description: description.trim() || undefined,
       });
       toast.success(initialData ? t('updateSuccess') : t('createSuccess'));
       router.push('/budgets');
@@ -239,6 +245,18 @@ export function BudgetForm({
                 </SelectContent>
               </Select>
             )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">{tCommon('description')}</Label>
+            <Textarea
+              id="description"
+              placeholder={t('descriptionPlaceholder')}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isLoading}
+              rows={3}
+            />
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -38,6 +38,7 @@ export const mockBudgets = [
   {
     id: 'budget-1',
     amount: '500.00',
+    description: null,
     categoryId: 'cat-2',
     month: 3,
     year: 2026,
@@ -47,6 +48,7 @@ export const mockBudgets = [
   {
     id: 'budget-2',
     amount: '3000.00',
+    description: null,
     categoryId: 'cat-1',
     month: 3,
     year: 2026,
@@ -109,6 +111,7 @@ export const mockTransactions = [
 export const mockBudgetWithDetails = {
   id: 'budget-1',
   amount: '500.00',
+  description: null,
   categoryId: 'cat-2',
   month: 3,
   year: 2026,
@@ -124,6 +127,7 @@ export const mockBudgetsWithSpending = [
   {
     id: 'budget-1',
     amount: '500.00',
+    description: null,
     categoryId: 'cat-2',
     month: 3,
     year: 2026,
@@ -135,6 +139,7 @@ export const mockBudgetsWithSpending = [
   {
     id: 'budget-2',
     amount: '3000.00',
+    description: null,
     categoryId: 'cat-1',
     month: 3,
     year: 2026,

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -144,6 +144,7 @@ export enum BudgetType {
 export interface Budget {
   id: string;
   amount: string;
+  description: string | null;
   categoryId: string;
   month: number;
   year: number;
@@ -156,6 +157,7 @@ export interface CreateBudgetDto {
   categoryId: string;
   month: number;
   year: number;
+  description?: string;
 }
 
 export interface CreateBatchBudgetDto {
@@ -177,11 +179,13 @@ export interface UpdateBudgetDto {
   categoryId?: string;
   month?: number;
   year?: number;
+  description?: string | null;
 }
 
 interface BudgetWithSpendingBase {
   id: string;
   amount: string;
+  description: string | null;
   categoryId: string;
   month: number;
   year: number;

--- a/prisma/migrations/20260412141111_add_description_to_budget/migration.sql
+++ b/prisma/migrations/20260412141111_add_description_to_budget/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Account" ALTER COLUMN "id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Budget" ADD COLUMN     "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Transaction {
 model Budget {
   id           String     @id @default(uuid()) @db.Uuid
   amount       Decimal    @db.Decimal(10, 2)
+  description  String?
   month        Int
   year         Int
   type         BudgetType


### PR DESCRIPTION
Add an optional description field to budgets across the full stack:
- Prisma schema + migration (nullable String column)
- Backend DTOs (create/update/response) and service (budgetSelect, mapBudget, create/update data)
- Frontend types, BudgetForm textarea, BudgetDetails display, edit page initialData
- i18n keys for EN and PT-BR; shadcn Textarea component added
- Updated tests (backend spec + frontend component tests + MSW handlers)