### PR TITLE
feat(export): add CSV export for transactions and budgets

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
     "bcryptjs": "^3.0.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "csv-stringify": "^6.7.0",
     "helmet": "^8.1.0",
     "joi": "^17.13.3",
     "nestjs-i18n": "^10.6.0",

--- a/apps/api/src/i18n/en/budgets.json
+++ b/apps/api/src/i18n/en/budgets.json
@@ -6,5 +6,19 @@
     "invalidType": "Invalid budget type: {type}",
     "invalidMonth": "Month must be between 1 and 12",
     "invalidDateRange": "End date must be after or equal to start date"
+  },
+  "csv": {
+    "headers": {
+      "month": "Month",
+      "year": "Year",
+      "type": "Type",
+      "category": "Category",
+      "amount": "Amount",
+      "description": "Description"
+    },
+    "values": {
+      "income": "Income",
+      "expense": "Expense"
+    }
   }
 }

--- a/apps/api/src/i18n/en/transactions.json
+++ b/apps/api/src/i18n/en/transactions.json
@@ -4,5 +4,19 @@
     "categoryNotFound": "Category with ID {id} does not exist",
     "invalidType": "Invalid transaction type: {type}",
     "accountNotFound": "Account with ID {id} does not exist or does not belong to you"
+  },
+  "csv": {
+    "headers": {
+      "date": "Date",
+      "type": "Type",
+      "amount": "Amount",
+      "category": "Category",
+      "account": "Account",
+      "description": "Description"
+    },
+    "values": {
+      "income": "Income",
+      "expense": "Expense"
+    }
   }
 }

--- a/apps/api/src/i18n/pt-BR/budgets.json
+++ b/apps/api/src/i18n/pt-BR/budgets.json
@@ -6,5 +6,19 @@
     "invalidType": "Tipo de orçamento inválido: {type}",
     "invalidMonth": "O mês deve estar entre 1 e 12",
     "invalidDateRange": "A data de término deve ser igual ou posterior à data de início"
+  },
+  "csv": {
+    "headers": {
+      "month": "Mês",
+      "year": "Ano",
+      "type": "Tipo",
+      "category": "Categoria",
+      "amount": "Valor",
+      "description": "Descrição"
+    },
+    "values": {
+      "income": "Receita",
+      "expense": "Despesa"
+    }
   }
 }

--- a/apps/api/src/i18n/pt-BR/transactions.json
+++ b/apps/api/src/i18n/pt-BR/transactions.json
@@ -4,5 +4,19 @@
     "categoryNotFound": "Categoria com ID {id} não existe",
     "invalidType": "Tipo de transação inválido: {type}",
     "accountNotFound": "Conta com ID {id} não existe ou não pertence a você"
+  },
+  "csv": {
+    "headers": {
+      "date": "Data",
+      "type": "Tipo",
+      "amount": "Valor",
+      "category": "Categoria",
+      "account": "Conta",
+      "description": "Descrição"
+    },
+    "values": {
+      "income": "Receita",
+      "expense": "Despesa"
+    }
   }
 }

--- a/apps/api/src/modules/budgets/budget.controller.ts
+++ b/apps/api/src/modules/budgets/budget.controller.ts
@@ -10,8 +10,11 @@ import {
   Query,
   UseGuards,
   Request,
+  Res,
+  Headers,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { BudgetService } from './budget.service';
 import {
   ApiGetAllBudgets,
@@ -27,8 +30,16 @@ import { CreateBudgetDto } from './dto/create-budget.dto';
 import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 import { GetBudgetsQueryDto } from './dto/get-budgets-query.dto';
+import { ExportBudgetsQueryDto } from './dto/export-budgets-query.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
+
+function resolveLang(header?: string): string {
+  if (!header) return 'en';
+  const first = header.split(',')[0]?.trim().toLowerCase() ?? 'en';
+  if (first.startsWith('pt')) return 'pt-BR';
+  return 'en';
+}
 
 @ApiTags('budgets')
 @Controller('budgets')
@@ -44,6 +55,25 @@ export class BudgetController {
     @Query() query: GetBudgetsQueryDto,
   ): ReturnType<BudgetService['getAllBudgets']> {
     return this.budgetService.getAllBudgets(req.user.userId, query);
+  }
+
+  @Get('export')
+  async exportBudgets(
+    @Request() req: AuthenticatedRequest,
+    @Query() query: ExportBudgetsQueryDto,
+    @Headers('accept-language') acceptLanguage: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    const lang = resolveLang(acceptLanguage);
+    const csv = await this.budgetService.exportBudgets(
+      req.user.userId,
+      query,
+      lang,
+    );
+    const filename = `budgets-${new Date().toISOString().slice(0, 10)}.csv`;
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(csv);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/budgets/budget.service.spec.ts
+++ b/apps/api/src/modules/budgets/budget.service.spec.ts
@@ -1694,4 +1694,44 @@ describe('BudgetService', () => {
       expect(result).toEqual({ created: 1, skipped: 0 });
     });
   });
+
+  describe('exportBudgets', () => {
+    it('should return CSV with BOM, translated headers, and joined category name', async () => {
+      prismaMock.budget.findMany = jest.fn().mockResolvedValueOnce([
+        {
+          id: 'b-1',
+          amount: 200,
+          description: 'May groceries',
+          month: 5,
+          year: 2026,
+          type: BudgetType.EXPENSE,
+          category: { name: 'Groceries' },
+        },
+      ]);
+
+      const csv = await service.exportBudgets(userId, {}, 'en');
+
+      expect(csv.charCodeAt(0)).toBe(0xfeff);
+      expect(csv).toContain('budgets.csv.headers.month');
+      expect(csv).toContain('budgets.csv.values.expense');
+      expect(csv).toContain('Groceries');
+      expect(csv).toContain('May groceries');
+      expect(csv).toContain('200.00');
+    });
+
+    it('should pass month/year/type to prisma where clause', async () => {
+      const spy = jest.fn().mockResolvedValue([]);
+      prismaMock.budget.findMany = spy;
+      await service.exportBudgets(
+        userId,
+        { month: 5, year: 2026, type: BudgetType.INCOME },
+        'en',
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId, month: 5, year: 2026, type: BudgetType.INCOME },
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -6,10 +6,12 @@ import {
 } from '@nestjs/common';
 import { BudgetType, Prisma, TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
+import { stringify } from 'csv-stringify/sync';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { CreateBatchBudgetDto } from './dto/create-batch-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 import { GetBudgetsQueryDto } from './dto/get-budgets-query.dto';
+import { ExportBudgetsQueryDto } from './dto/export-budgets-query.dto';
 import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
 import { formatDecimal } from '../shared';
@@ -697,6 +699,62 @@ export class BudgetService {
       remaining: formatDecimal(remaining),
       utilizationPercentage,
     };
+  }
+
+  async exportBudgets(
+    userId: string,
+    query: ExportBudgetsQueryDto = {},
+    lang: string = 'en',
+  ): Promise<string> {
+    const where: Record<string, unknown> = { userId };
+
+    if (query.month !== undefined) {
+      where['month'] = query.month;
+    }
+    if (query.year !== undefined) {
+      where['year'] = query.year;
+    }
+    if (query.type) {
+      where['type'] = query.type;
+    }
+
+    const budgets = await this.prisma.budget.findMany({
+      where,
+      select: {
+        id: true,
+        amount: true,
+        description: true,
+        month: true,
+        year: true,
+        type: true,
+        category: { select: { name: true } },
+      },
+      orderBy: [{ year: 'desc' }, { month: 'desc' }],
+    });
+
+    const t = (key: string): string =>
+      this.i18n.t(`budgets.csv.${key}`, { lang });
+
+    const headers = [
+      t('headers.month'),
+      t('headers.year'),
+      t('headers.type'),
+      t('headers.category'),
+      t('headers.amount'),
+      t('headers.description'),
+    ];
+
+    const rows = budgets.map((row) => [
+      String(row.month),
+      String(row.year),
+      row.type === BudgetType.INCOME ? t('values.income') : t('values.expense'),
+      row.category?.name ?? '',
+      formatDecimal(row.amount),
+      row.description ?? '',
+    ]);
+
+    const csv = stringify([headers, ...rows]);
+    return `\uFEFF${csv}`;
   }
 
   async getBudgetsByCategory(

--- a/apps/api/src/modules/budgets/dto/export-budgets-query.dto.ts
+++ b/apps/api/src/modules/budgets/dto/export-budgets-query.dto.ts
@@ -1,0 +1,22 @@
+import { IsEnum, IsInt, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { BudgetType } from '@prisma/client';
+
+export class ExportBudgetsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  year?: number;
+
+  @IsOptional()
+  @IsEnum(BudgetType)
+  type?: BudgetType;
+}

--- a/apps/api/src/modules/transactions/dto/export-transactions-query.dto.ts
+++ b/apps/api/src/modules/transactions/dto/export-transactions-query.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsOptional, IsUUID, IsDateString } from 'class-validator';
+import { TransactionType } from '@prisma/client';
+
+export class ExportTransactionsQueryDto {
+  @IsOptional()
+  @IsEnum(TransactionType)
+  type?: TransactionType;
+
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/apps/api/src/modules/transactions/transactions.controller.ts
+++ b/apps/api/src/modules/transactions/transactions.controller.ts
@@ -10,8 +10,11 @@ import {
   Query,
   UseGuards,
   Request,
+  Res,
+  Headers,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { TransactionsService } from './transactions.service';
 import {
   ApiGetAllTransactions,
@@ -23,8 +26,16 @@ import {
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
+import { ExportTransactionsQueryDto } from './dto/export-transactions-query.dto';
 import { JwtAuthGuard } from '../auths/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../auths/interfaces/authenticated-request.interface';
+
+function resolveLang(header?: string): string {
+  if (!header) return 'en';
+  const first = header.split(',')[0]?.trim().toLowerCase() ?? 'en';
+  if (first.startsWith('pt')) return 'pt-BR';
+  return 'en';
+}
 
 @ApiTags('transactions')
 @Controller('transactions')
@@ -40,6 +51,25 @@ export class TransactionController {
     @Query() query: GetTransactionsQueryDto,
   ): ReturnType<TransactionsService['getAllTransactions']> {
     return this.transactionsService.getAllTransactions(req.user.userId, query);
+  }
+
+  @Get('export')
+  async exportTransactions(
+    @Request() req: AuthenticatedRequest,
+    @Query() query: ExportTransactionsQueryDto,
+    @Headers('accept-language') acceptLanguage: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    const lang = resolveLang(acceptLanguage);
+    const csv = await this.transactionsService.exportTransactions(
+      req.user.userId,
+      query,
+      lang,
+    );
+    const filename = `transactions-${new Date().toISOString().slice(0, 10)}.csv`;
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(csv);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/transactions/transactions.service.spec.ts
+++ b/apps/api/src/modules/transactions/transactions.service.spec.ts
@@ -726,4 +726,52 @@ describe('TransactionsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('exportTransactions', () => {
+    it('should return CSV with BOM, translated headers, and joined names', async () => {
+      prismaMock.transaction.findMany = jest.fn().mockResolvedValueOnce([
+        {
+          id: 'tx-1',
+          amount: 12.5,
+          type: TransactionType.EXPENSE,
+          date: new Date('2025-03-15T12:00:00.000Z'),
+          description: 'Lunch, with friend',
+          category: { name: 'Food' },
+          account: { name: 'Wallet' },
+        },
+      ]);
+
+      const csv = await service.exportTransactions(userId, {}, 'en');
+
+      expect(csv.charCodeAt(0)).toBe(0xfeff);
+      expect(csv).toContain('transactions.csv.headers.date');
+      expect(csv).toContain('transactions.csv.values.expense');
+      expect(csv).toContain('"Lunch, with friend"');
+      expect(csv).toContain('Food');
+      expect(csv).toContain('Wallet');
+      expect(csv).toContain('2025-03-15');
+      expect(csv).toContain('12.50');
+    });
+
+    it('should pass date filters to prisma where clause', async () => {
+      const spy = jest.fn().mockResolvedValue([]);
+      prismaMock.transaction.findMany = spy;
+      await service.exportTransactions(
+        userId,
+        { startDate: '2025-01-01', endDate: '2025-01-31' },
+        'en',
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId,
+            date: expect.objectContaining({
+              gte: expect.any(Date),
+              lte: expect.any(Date),
+            }),
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/transactions/transactions.service.ts
+++ b/apps/api/src/modules/transactions/transactions.service.ts
@@ -5,9 +5,11 @@ import {
 } from '@nestjs/common';
 import { TransactionType } from '@prisma/client';
 import { I18nService, I18nContext } from 'nestjs-i18n';
+import { stringify } from 'csv-stringify/sync';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
+import { ExportTransactionsQueryDto } from './dto/export-transactions-query.dto';
 import { CategoriesService } from '../categories/categories.service';
 import { PrismaService } from '../shared/prisma.service';
 import { formatDecimal } from '../shared';
@@ -259,6 +261,75 @@ export class TransactionsService {
     });
 
     return this.mapTransaction(updatedTransaction);
+  }
+
+  async exportTransactions(
+    userId: string,
+    query: ExportTransactionsQueryDto = {},
+    lang: string = 'en',
+  ): Promise<string> {
+    const where: Record<string, unknown> = { userId };
+
+    if (query.type) {
+      where['type'] = query.type;
+    }
+
+    if (query.categoryId) {
+      where['categoryId'] = query.categoryId;
+    }
+
+    if (query.startDate || query.endDate) {
+      const dateFilter: Record<string, Date> = {};
+      if (query.startDate) {
+        dateFilter['gte'] = new Date(query.startDate);
+      }
+      if (query.endDate) {
+        dateFilter['lte'] = new Date(
+          `${query.endDate.slice(0, 10)}T23:59:59.999Z`,
+        );
+      }
+      where['date'] = dateFilter;
+    }
+
+    const transactions = await this.prisma.transaction.findMany({
+      where,
+      select: {
+        id: true,
+        amount: true,
+        type: true,
+        date: true,
+        description: true,
+        category: { select: { name: true } },
+        account: { select: { name: true } },
+      },
+      orderBy: { date: 'desc' },
+    });
+
+    const t = (key: string): string =>
+      this.i18n.t(`transactions.csv.${key}`, { lang });
+
+    const headers = [
+      t('headers.date'),
+      t('headers.type'),
+      t('headers.amount'),
+      t('headers.category'),
+      t('headers.account'),
+      t('headers.description'),
+    ];
+
+    const rows = transactions.map((row) => [
+      row.date.toISOString().slice(0, 10),
+      row.type === TransactionType.INCOME
+        ? t('values.income')
+        : t('values.expense'),
+      formatDecimal(row.amount),
+      row.category?.name ?? '',
+      row.account?.name ?? '',
+      row.description ?? '',
+    ]);
+
+    const csv = stringify([headers, ...rows]);
+    return `\uFEFF${csv}`;
   }
 
   async deleteTransaction(id: string, userId: string) {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -185,7 +185,10 @@
     "failedToDelete": "Failed to delete transaction",
     "createTitle": "Create Transaction",
     "editTitle": "Edit Transaction",
-    "failedToLoadSingle": "Failed to load transaction"
+    "failedToLoadSingle": "Failed to load transaction",
+    "exportCsv": "Export CSV",
+    "exportSuccess": "Transactions exported successfully",
+    "exportError": "Failed to export transactions"
   },
   "accounts": {
     "title": "Accounts",
@@ -260,7 +263,10 @@
     "editTitle": "Edit Budget",
     "failedToLoadSingle": "Failed to load budget",
     "notFound": "Budget not found",
-    "detailsTitle": "Budget Details"
+    "detailsTitle": "Budget Details",
+    "exportCsv": "Export CSV",
+    "exportSuccess": "Budgets exported successfully",
+    "exportError": "Failed to export budgets"
   },
   "budgetForm": {
     "amountPlaceholder": "e.g., 500.00",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -185,7 +185,10 @@
     "failedToDelete": "Falha ao excluir transação",
     "createTitle": "Criar Transação",
     "editTitle": "Editar Transação",
-    "failedToLoadSingle": "Falha ao carregar transação"
+    "failedToLoadSingle": "Falha ao carregar transação",
+    "exportCsv": "Exportar CSV",
+    "exportSuccess": "Transações exportadas com sucesso",
+    "exportError": "Falha ao exportar transações"
   },
   "accounts": {
     "title": "Contas",
@@ -260,7 +263,10 @@
     "editTitle": "Editar Orçamento",
     "failedToLoadSingle": "Falha ao carregar orçamento",
     "notFound": "Orçamento não encontrado",
-    "detailsTitle": "Detalhes do Orçamento"
+    "detailsTitle": "Detalhes do Orçamento",
+    "exportCsv": "Exportar CSV",
+    "exportSuccess": "Orçamentos exportados com sucesso",
+    "exportError": "Falha ao exportar orçamentos"
   },
   "budgetForm": {
     "amountPlaceholder": "ex.: 500,00",

--- a/apps/web/src/app/budgets/page.tsx
+++ b/apps/web/src/app/budgets/page.tsx
@@ -12,6 +12,7 @@ import { Budget, Category, BudgetType } from '@/types';
 import { AuthLayout } from '@/components/layouts/AuthLayout';
 import { BudgetsTableSkeleton } from '@/components/BudgetsTableSkeleton';
 import { Pagination } from '@/components/Pagination';
+import { ExportCsvButton } from '@/components/ExportCsvButton';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -378,6 +379,21 @@ export default function BudgetsPage() {
             ))}
           </SelectContent>
         </Select>
+
+        <ExportCsvButton
+          onExport={() =>
+            budgetsApi.exportCsv({
+              month:
+                filterMonth !== 'ALL' ? (filterMonth as number) : undefined,
+              year: filterYear !== 'ALL' ? (filterYear as number) : undefined,
+              type: filterType !== 'ALL' ? filterType : undefined,
+            })
+          }
+          filenamePrefix="budgets"
+          label={t('exportCsv')}
+          successMessage={t('exportSuccess')}
+          errorMessage={t('exportError')}
+        />
       </div>
 
       {hasSpendingInfo && filterCategory !== 'ALL' && (

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -12,6 +12,7 @@ import { Transaction, Category, TransactionType } from '@/types';
 import { AuthLayout } from '@/components/layouts/AuthLayout';
 import { TransactionsTableSkeleton } from '@/components/TransactionsTableSkeleton';
 import { Pagination } from '@/components/Pagination';
+import { ExportCsvButton } from '@/components/ExportCsvButton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -258,6 +259,21 @@ export default function TransactionsPage() {
         <Button variant="outline" onClick={clearFilters}>
           {tCommon('clearFilters')}
         </Button>
+
+        <ExportCsvButton
+          onExport={() =>
+            transactionsApi.exportCsv({
+              type: filterType !== 'ALL' ? filterType : undefined,
+              categoryId: filterCategory !== 'ALL' ? filterCategory : undefined,
+              startDate: filterStartDate || undefined,
+              endDate: filterEndDate || undefined,
+            })
+          }
+          filenamePrefix="transactions"
+          label={t('exportCsv')}
+          successMessage={t('exportSuccess')}
+          errorMessage={t('exportError')}
+        />
       </div>
 
       <div className="bg-card rounded-lg shadow">

--- a/apps/web/src/components/ExportCsvButton.test.tsx
+++ b/apps/web/src/components/ExportCsvButton.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { ExportCsvButton } from './ExportCsvButton';
+import { renderWithProviders, setupUser } from '@/test/test-utils';
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: toastMocks.success, error: toastMocks.error },
+}));
+
+describe('ExportCsvButton', () => {
+  beforeEach(() => {
+    toastMocks.success.mockReset();
+    toastMocks.error.mockReset();
+  });
+
+  it('fetches blob, triggers download, and shows success toast', async () => {
+    const user = setupUser();
+    const blob = new Blob(['﻿h1,h2\n'], { type: 'text/csv' });
+    const onExport = vi.fn().mockResolvedValue(blob);
+    const createObjectURL = vi.fn().mockReturnValue('blob:fake');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      value: createObjectURL,
+      configurable: true,
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      value: revokeObjectURL,
+      configurable: true,
+    });
+    const anchorClick = vi.fn();
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', { value: anchorClick });
+      }
+      return el;
+    });
+
+    renderWithProviders(
+      <ExportCsvButton
+        onExport={onExport}
+        filenamePrefix="transactions"
+        label="Export CSV"
+        successMessage="ok"
+        errorMessage="fail"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalled());
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(anchorClick).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+    expect(toastMocks.success).toHaveBeenCalledWith('ok');
+  });
+
+  it('shows error toast on failure', async () => {
+    const user = setupUser();
+    const onExport = vi.fn().mockRejectedValue(new Error('boom'));
+
+    renderWithProviders(
+      <ExportCsvButton
+        onExport={onExport}
+        filenamePrefix="x"
+        label="Export CSV"
+        successMessage="ok"
+        errorMessage="fail"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => expect(toastMocks.error).toHaveBeenCalledWith('fail'));
+  });
+});

--- a/apps/web/src/components/ExportCsvButton.tsx
+++ b/apps/web/src/components/ExportCsvButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { ApiException } from '@/lib/api';
+
+interface ExportCsvButtonProps {
+  onExport: () => Promise<Blob>;
+  filenamePrefix: string;
+  label: string;
+  successMessage: string;
+  errorMessage: string;
+}
+
+export function ExportCsvButton({
+  onExport,
+  filenamePrefix,
+  label,
+  successMessage,
+  errorMessage,
+}: ExportCsvButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    try {
+      const blob = await onExport();
+      const url = URL.createObjectURL(blob);
+      const today = new Date().toISOString().slice(0, 10);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `${filenamePrefix}-${today}.csv`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+      toast.success(successMessage);
+    } catch (error) {
+      if (error instanceof ApiException) {
+        toast.error(error.message);
+      } else {
+        toast.error(errorMessage);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={handleClick}
+      disabled={loading}
+      aria-label={label}
+    >
+      <Download className="size-4" />
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -78,16 +78,21 @@ async function tryRefreshToken(): Promise<string | null> {
   }
 }
 
+export interface ApiRequestOptions extends RequestInit {
+  responseType?: 'json' | 'blob';
+}
+
 export async function apiRequest<T>(
   endpoint: string,
-  options: RequestInit = {},
+  options: ApiRequestOptions = {},
   _isRetry = false,
 ): Promise<T> {
   const token = getToken();
+  const { responseType = 'json', ...fetchOptions } = options;
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
     'Accept-Language': getLocale(),
-    ...options.headers,
+    ...fetchOptions.headers,
   };
 
   if (token) {
@@ -95,7 +100,7 @@ export async function apiRequest<T>(
   }
 
   const response = await fetch(`${API_URL}${endpoint}`, {
-    ...options,
+    ...fetchOptions,
     headers,
   });
 
@@ -128,6 +133,10 @@ export async function apiRequest<T>(
   // Handle 204 No Content
   if (response.status === 204) {
     return undefined as T;
+  }
+
+  if (responseType === 'blob') {
+    return (await response.blob()) as unknown as T;
   }
 
   return response.json();

--- a/apps/web/src/lib/budgets.ts
+++ b/apps/web/src/lib/budgets.ts
@@ -1,4 +1,4 @@
-import { api } from '@/lib/api';
+import { api, apiRequest } from '@/lib/api';
 import { PaginatedResponse } from '@/lib/types';
 import {
   Budget,
@@ -13,6 +13,12 @@ import {
 export interface GetBudgetsParams {
   page?: number;
   limit?: number;
+  month?: number;
+  year?: number;
+  type?: string;
+}
+
+export interface ExportBudgetsParams {
   month?: number;
   year?: number;
   type?: string;
@@ -51,4 +57,18 @@ export const budgetsApi = {
     api.put<Budget>(`/budgets/${id}`, data),
 
   delete: (id: string) => api.delete<void>(`/budgets/${id}`),
+
+  exportCsv: (params?: ExportBudgetsParams) => {
+    const searchParams = new URLSearchParams();
+    if (params?.month !== undefined)
+      searchParams.set('month', String(params.month));
+    if (params?.year !== undefined)
+      searchParams.set('year', String(params.year));
+    if (params?.type) searchParams.set('type', params.type);
+    const qs = searchParams.toString();
+    return apiRequest<Blob>(`/budgets/export${qs ? `?${qs}` : ''}`, {
+      method: 'GET',
+      responseType: 'blob',
+    });
+  },
 };

--- a/apps/web/src/lib/transactions.ts
+++ b/apps/web/src/lib/transactions.ts
@@ -1,4 +1,4 @@
-import { api } from '@/lib/api';
+import { api, apiRequest } from '@/lib/api';
 import { PaginatedResponse } from '@/lib/types';
 import {
   Transaction,
@@ -9,6 +9,13 @@ import {
 export interface GetTransactionsParams {
   page?: number;
   limit?: number;
+  type?: string;
+  categoryId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface ExportTransactionsParams {
   type?: string;
   categoryId?: string;
   startDate?: string;
@@ -41,4 +48,17 @@ export const transactionsApi = {
     api.put<Transaction>(`/transactions/${id}`, data),
 
   delete: (id: string) => api.delete<void>(`/transactions/${id}`),
+
+  exportCsv: (params?: ExportTransactionsParams) => {
+    const searchParams = new URLSearchParams();
+    if (params?.type) searchParams.set('type', params.type);
+    if (params?.categoryId) searchParams.set('categoryId', params.categoryId);
+    if (params?.startDate) searchParams.set('startDate', params.startDate);
+    if (params?.endDate) searchParams.set('endDate', params.endDate);
+    const qs = searchParams.toString();
+    return apiRequest<Blob>(`/transactions/export${qs ? `?${qs}` : ''}`, {
+      method: 'GET',
+      responseType: 'blob',
+    });
+  },
 };

--- a/apps/web/src/test/mocks/handlers.ts
+++ b/apps/web/src/test/mocks/handlers.ts
@@ -1238,4 +1238,40 @@ export const handlers = [
       return HttpResponse.json({ ...user, isActive: body.isActive });
     },
   ),
+
+  http.get(`${API_URL}/transactions/export`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    const csv = '﻿Date,Type,Amount,Category,Account,Description\n';
+    return new HttpResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="transactions-test.csv"',
+      },
+    });
+  }),
+
+  http.get(`${API_URL}/budgets/export`, ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { message: 'Unauthorized', statusCode: 401 },
+        { status: 401 },
+      );
+    }
+    const csv = '﻿Month,Year,Type,Category,Amount,Description\n';
+    return new HttpResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="budgets-test.csv"',
+      },
+    });
+  }),
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "bcryptjs": "^3.0.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "csv-stringify": "^6.7.0",
         "helmet": "^8.1.0",
         "joi": "^17.13.3",
         "nestjs-i18n": "^10.6.0",
@@ -9870,6 +9871,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
+      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ=="
     },
     "node_modules/d3-array": {
       "version": "3.2.4",


### PR DESCRIPTION
Adds GET /transactions/export and GET /budgets/export endpoints returning text/csv attachments with UTF-8 BOM, translated headers via Accept-Language, and joined category/account names. Frontend ExportCsvButton on list pages triggers download using current filters. csv-stringify used for escaping.