### PR TITLE
feat(web): add premium conversion-focused landing page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@my-pocket/shared": "*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.42.2",
     "lucide-react": "^0.576.0",
     "next": "^15.2.0",
     "next-intl": "^4.8.3",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,6 +5,9 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+    --color-brand: var(--brand);
+    --color-brand-glow: var(--brand-glow);
+    --color-brand-subtle: var(--brand-subtle);
     --radius-sm: calc(var(--radius) - 4px);
     --radius-md: calc(var(--radius) - 2px);
     --radius-lg: var(--radius);
@@ -47,6 +50,9 @@
 
 :root {
     --radius: 0.625rem;
+    --brand: oklch(0.696 0.17 162.48);
+    --brand-glow: oklch(0.696 0.17 162.48 / 20%);
+    --brand-subtle: oklch(0.696 0.17 162.48 / 8%);
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -3,7 +3,25 @@ import { screen } from '@testing-library/react';
 import { renderWithProviders } from '@/test/test-utils';
 import HomePage from './page';
 
-// Mock next/navigation
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion');
+  return {
+    ...actual,
+    motion: new Proxy(actual.motion, {
+      get: (target, prop: string) => {
+        const el = (target as Record<string, unknown>)[prop];
+        if (el) return el;
+        return ({ children, ...rest }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) => {
+          const Tag = prop as keyof JSX.IntrinsicElements;
+          return <Tag {...(rest as object)}>{children}</Tag>;
+        };
+      },
+    }),
+    useInView: () => true,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
 const mockRouterPush = vi.fn();
 vi.mock('next/navigation', async () => ({
   useRouter: () => ({
@@ -13,11 +31,9 @@ vi.mock('next/navigation', async () => ({
   }),
 }));
 
-// Mock useAuth
 const mockUseAuth = vi.fn();
 vi.mock('@/contexts/AuthContext', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@/contexts/AuthContext')>();
+  const actual = await importOriginal<typeof import('@/contexts/AuthContext')>();
   return {
     ...actual,
     useAuth: () => mockUseAuth(),
@@ -29,105 +45,68 @@ describe('HomePage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders loading state when isLoading is true', () => {
+  it('renders nothing while loading', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
-
-    renderWithProviders(<HomePage />);
-
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    const { container } = renderWithProviders(<HomePage />);
+    expect(container.firstChild).toBeNull();
   });
 
   it('redirects to /dashboard when authenticated', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
-
     renderWithProviders(<HomePage />);
-
     expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
   });
 
   it('renders hero headline for unauthenticated users', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
     renderWithProviders(<HomePage />);
-
-    expect(
-      screen.getByText(
-        "When you don't know where your money goes, how can you expect to make more?",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'The first step for great gains is being fully aware of your actual financial situation.',
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Take back control')).toBeInTheDocument();
+    expect(screen.getByText('of your money.')).toBeInTheDocument();
   });
 
-  it('renders all three feature cards', () => {
+  it('renders features section', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
     renderWithProviders(<HomePage />);
-
-    expect(screen.getByText('Track Every Transaction')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Know exactly where every cent goes. Log income and expenses in seconds.',
-      ),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Set Smart Budgets')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Plan ahead by category. Set monthly targets and stay in control of your spending.',
-      ),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Visualize Your Progress')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Clear charts and reports give you a complete picture of your financial health.',
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Dashboard at a glance')).toBeInTheDocument();
+    expect(screen.getByText('Smart budgets')).toBeInTheDocument();
+    expect(screen.getByText('Visual insights')).toBeInTheDocument();
   });
 
-  it('renders CTA section with button', () => {
+  it('renders "start for free" CTA links pointing to /register', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
     renderWithProviders(<HomePage />);
-
-    expect(screen.getByText('Start taking control today')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Awareness is the foundation of every great financial decision.',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Get Started Free' }),
-    ).toHaveAttribute('href', '/register');
+    const ctaLinks = screen.getAllByRole('link', { name: /start for free/i });
+    expect(ctaLinks.length).toBeGreaterThanOrEqual(1);
+    ctaLinks.forEach((link) => expect(link).toHaveAttribute('href', '/register'));
   });
 
-  it('Sign In link points to /login', () => {
+  it('renders sign in links pointing to /login', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
     renderWithProviders(<HomePage />);
-
-    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
-      'href',
-      '/login',
-    );
+    const signInLinks = screen.getAllByRole('link', { name: /sign in/i });
+    expect(signInLinks.length).toBeGreaterThanOrEqual(1);
+    signInLinks.forEach((link) => expect(link).toHaveAttribute('href', '/login'));
   });
 
-  it('Get Started link in hero points to /register', () => {
+  it('renders testimonials section', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
     renderWithProviders(<HomePage />);
+    expect(screen.getByText('Marcus R.')).toBeInTheDocument();
+    expect(screen.getByText('Sofia C.')).toBeInTheDocument();
+    expect(screen.getByText('James T.')).toBeInTheDocument();
+  });
 
-    const getStartedLinks = screen.getAllByRole('link', {
-      name: /get started/i,
-    });
-    expect(
-      getStartedLinks.every(
-        (link) => link.getAttribute('href') === '/register',
-      ),
-    ).toBe(true);
+  it('renders free pricing section', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    renderWithProviders(<HomePage />);
+    expect(screen.getByText('$0')).toBeInTheDocument();
+    expect(screen.getByText(/Completely free\./)).toBeInTheDocument();
+  });
+
+  it('renders FAQ section', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    renderWithProviders(<HomePage />);
+    expect(screen.getByText('Is My Pocket really free?')).toBeInTheDocument();
+    expect(screen.getByText('Does it connect to my bank?')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,18 +2,22 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { TrendingUp, Target, BarChart3 } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { LandingNav } from '@/components/landing/LandingNav';
+import { HeroSection } from '@/components/landing/HeroSection';
+import { SocialProofSection } from '@/components/landing/SocialProofSection';
+import { FeaturesSection } from '@/components/landing/FeaturesSection';
+import { ProductShowcaseSection } from '@/components/landing/ProductShowcaseSection';
+import { BenefitsSection } from '@/components/landing/BenefitsSection';
+import { TestimonialsSection } from '@/components/landing/TestimonialsSection';
+import { FreeSection } from '@/components/landing/FreeSection';
+import { FAQSection } from '@/components/landing/FAQSection';
+import { CTASection } from '@/components/landing/CTASection';
+import { FooterSection } from '@/components/landing/FooterSection';
 
 export default function Home() {
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
-  const t = useTranslations('home');
-  const tCommon = useTranslations('common');
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
@@ -21,88 +25,21 @@ export default function Home() {
     }
   }, [isLoading, isAuthenticated, router]);
 
-  if (isLoading) {
-    return (
-      <main className="flex min-h-screen flex-col items-center justify-center p-24">
-        <p className="text-muted-foreground">{tCommon('loading')}</p>
-      </main>
-    );
-  }
+  if (isLoading) return null;
 
   return (
-    <main className="flex min-h-screen flex-col bg-background">
-      {/* Hero Section */}
-      <section className="flex flex-1 flex-col items-center justify-center px-6 py-24 text-center">
-        <span className="mb-6 inline-block rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
-          My Pocket
-        </span>
-        <h1 className="mb-6 max-w-3xl text-4xl font-bold leading-tight tracking-tight sm:text-5xl lg:text-6xl">
-          {t('headline')}
-        </h1>
-        <p className="mb-10 max-w-xl text-lg text-muted-foreground">
-          {t('subheadline')}
-        </p>
-        <div className="flex flex-wrap gap-4 justify-center">
-          <Link href="/login">
-            <Button variant="outline" size="lg">
-              {t('signIn')}
-            </Button>
-          </Link>
-          <Link href="/register">
-            <Button size="lg">{t('getStarted')}</Button>
-          </Link>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="px-6 py-20">
-        <div className="mx-auto grid max-w-5xl gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          <Card>
-            <CardHeader>
-              <TrendingUp className="mb-2 h-8 w-8 text-primary" />
-              <CardTitle>{t('features.track.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                {t('features.track.description')}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <Target className="mb-2 h-8 w-8 text-primary" />
-              <CardTitle>{t('features.budgets.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                {t('features.budgets.description')}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <BarChart3 className="mb-2 h-8 w-8 text-primary" />
-              <CardTitle>{t('features.insights.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                {t('features.insights.description')}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="bg-muted px-6 py-20 text-center">
-        <h2 className="mb-4 text-3xl font-bold">{t('ctaTitle')}</h2>
-        <p className="mb-8 text-lg text-muted-foreground">{t('ctaSubtitle')}</p>
-        <Link href="/register">
-          <Button size="lg">{t('ctaButton')}</Button>
-        </Link>
-      </section>
+    <main className="min-h-screen">
+      <LandingNav />
+      <HeroSection />
+      <SocialProofSection />
+      <FeaturesSection />
+      <ProductShowcaseSection />
+      <BenefitsSection />
+      <TestimonialsSection />
+      <FreeSection />
+      <FAQSection />
+      <CTASection />
+      <FooterSection />
     </main>
   );
 }

--- a/apps/web/src/components/landing/BenefitsSection.tsx
+++ b/apps/web/src/components/landing/BenefitsSection.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Eye, Zap, Lock } from 'lucide-react';
+
+const benefits = [
+  {
+    icon: Eye,
+    title: 'See the truth about your money',
+    body: 'Most people are shocked to see where they actually spend. My Pocket shows you the honest picture — no judgment, just data.',
+    highlight: 'Awareness is the first step.',
+  },
+  {
+    icon: Zap,
+    title: 'Build habits that stick',
+    body: 'Budgets you set today inform decisions you make tomorrow. Small, consistent awareness compounds into financial stability.',
+    highlight: 'Progress beats perfection.',
+  },
+  {
+    icon: Lock,
+    title: 'Your data stays yours',
+    body: "We don't sell your data, connect to your bank, or run ads. My Pocket is a tool you control — completely private by design.",
+    highlight: 'No open banking required.',
+  },
+];
+
+export function BenefitsSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section ref={ref} className="bg-gray-50 px-6 py-28">
+      <div className="mx-auto max-w-6xl">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="mb-16 text-center"
+        >
+          <span className="mb-4 inline-block rounded-full bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.45_0.15_162.48)]">
+            Why My Pocket
+          </span>
+          <h2 className="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Simple tools, real results
+          </h2>
+        </motion.div>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          {benefits.map((b, i) => (
+            <motion.div
+              key={b.title}
+              initial={{ opacity: 0, y: 32 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.6, delay: 0.1 + i * 0.12 }}
+              className="relative overflow-hidden rounded-2xl bg-white p-8 shadow-sm"
+            >
+              <div
+                aria-hidden
+                className="pointer-events-none absolute right-0 top-0 h-32 w-32 -translate-y-1/2 translate-x-1/2 rounded-full"
+                style={{
+                  background: 'oklch(0.696 0.17 162.48 / 6%)',
+                  filter: 'blur(24px)',
+                }}
+              />
+              <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-xl bg-[oklch(0.696_0.17_162.48/10%)]">
+                <b.icon className="h-6 w-6 text-[oklch(0.45_0.15_162.48)]" />
+              </div>
+              <h3 className="mb-3 text-lg font-semibold text-gray-900">{b.title}</h3>
+              <p className="mb-4 text-sm leading-relaxed text-gray-500">{b.body}</p>
+              <span className="inline-block rounded-lg bg-[oklch(0.696_0.17_162.48/10%)] px-3 py-1 text-xs font-medium text-[oklch(0.45_0.15_162.48)]">
+                {b.highlight}
+              </span>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/CTASection.tsx
+++ b/apps/web/src/components/landing/CTASection.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useRef } from 'react';
+import Link from 'next/link';
+import { motion, useInView } from 'framer-motion';
+import { ArrowRight } from 'lucide-react';
+
+export function CTASection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section ref={ref} className="relative overflow-hidden bg-black px-6 py-32 text-center">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 80% 60% at 50% 50%, oklch(0.696 0.17 162.48 / 15%) 0%, transparent 70%)',
+        }}
+      />
+
+      <div className="relative mx-auto max-w-3xl">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+        >
+          <h2 className="text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
+            Your finances won't
+            <br />
+            fix themselves.
+          </h2>
+          <p className="mx-auto mt-6 max-w-xl text-lg text-white/50">
+            Every day without clarity is another day of guessing. Start for free
+            today — it takes less time than your next coffee run.
+          </p>
+
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link
+              href="/register"
+              className="group inline-flex items-center gap-2 rounded-xl bg-[oklch(0.696_0.17_162.48)] px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-[oklch(0.696_0.17_162.48/25%)] transition-all duration-200 hover:brightness-110 hover:shadow-xl hover:shadow-[oklch(0.696_0.17_162.48/35%)]"
+            >
+              Start for free
+              <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+            </Link>
+          </div>
+
+          <p className="mt-4 text-xs text-white/30">
+            Free forever · No credit card · Takes 2 minutes
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/FAQSection.tsx
+++ b/apps/web/src/components/landing/FAQSection.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { motion, useInView, AnimatePresence } from 'framer-motion';
+import { Plus, Minus } from 'lucide-react';
+
+const faqs = [
+  {
+    q: 'Is My Pocket really free?',
+    a: 'Yes. My Pocket is completely free with no hidden fees, no premium tier, and no trial period. Every feature is available to every user, forever.',
+  },
+  {
+    q: 'Does it connect to my bank?',
+    a: "No — and that's intentional. You enter transactions manually. This keeps your banking credentials completely out of the picture and makes you more aware of each purchase as you log it.",
+  },
+  {
+    q: 'How is my data protected?',
+    a: 'Your data is stored securely, scoped strictly to your account, and never sold or shared. We don\'t run ads. Your financial data is yours.',
+  },
+  {
+    q: 'How long does it take to set up?',
+    a: "Most users have their accounts, categories, and first transactions set up in under 10 minutes. You'll see a meaningful dashboard on your first session.",
+  },
+  {
+    q: 'Can I track recurring bills and subscriptions?',
+    a: 'Yes. My Pocket has a dedicated recurring transactions feature. Log your rent, Netflix, gym membership — they\'ll be tracked automatically on their schedule.',
+  },
+  {
+    q: 'What if I have multiple bank accounts or credit cards?',
+    a: 'My Pocket supports unlimited accounts — checking, savings, credit cards, cash, and investment accounts. Every transaction is linked to an account and your balances update in real time.',
+  },
+];
+
+function FAQItem({ q, a }: { q: string; a: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border-b border-gray-100 last:border-0">
+      <button
+        onClick={() => setOpen(!open)}
+        className="group flex w-full items-start justify-between gap-4 py-5 text-left"
+        aria-expanded={open}
+      >
+        <span className="text-sm font-medium text-gray-900 group-hover:text-[oklch(0.45_0.15_162.48)] transition-colors duration-200">
+          {q}
+        </span>
+        <span className="mt-0.5 shrink-0 text-gray-400 transition-colors duration-200 group-hover:text-[oklch(0.696_0.17_162.48)]">
+          {open ? <Minus className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+        </span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <p className="pb-5 text-sm leading-relaxed text-gray-500">{a}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function FAQSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section id="faq" ref={ref} className="bg-white px-6 py-28">
+      <div className="mx-auto max-w-2xl">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="mb-12 text-center"
+        >
+          <span className="mb-4 inline-block rounded-full bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.45_0.15_162.48)]">
+            FAQ
+          </span>
+          <h2 className="mt-4 text-4xl font-bold tracking-tight text-gray-900">
+            Common questions
+          </h2>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="rounded-2xl border border-gray-100 bg-white px-6 shadow-sm"
+        >
+          {faqs.map((faq) => (
+            <FAQItem key={faq.q} {...faq} />
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/FeaturesSection.tsx
+++ b/apps/web/src/components/landing/FeaturesSection.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import {
+  LayoutDashboard,
+  Target,
+  BarChart3,
+  RefreshCw,
+  Wallet,
+  Bell,
+} from 'lucide-react';
+
+const features = [
+  {
+    icon: LayoutDashboard,
+    title: 'Dashboard at a glance',
+    description:
+      'See your complete financial picture the moment you log in — income, expenses, and balances unified in one view.',
+  },
+  {
+    icon: Target,
+    title: 'Smart budgets',
+    description:
+      'Set spending limits per category. My Pocket warns you before you overspend, not after.',
+  },
+  {
+    icon: BarChart3,
+    title: 'Visual insights',
+    description:
+      'Charts that reveal where your money actually goes — no spreadsheet skills required.',
+  },
+  {
+    icon: RefreshCw,
+    title: 'Recurring transactions',
+    description:
+      'Log subscriptions and bills once. My Pocket tracks them automatically so nothing slips through.',
+  },
+  {
+    icon: Wallet,
+    title: 'Multiple accounts',
+    description:
+      'Checking, savings, credit cards, cash — all in one place with real-time balance calculations.',
+  },
+  {
+    icon: Bell,
+    title: 'Category tracking',
+    description:
+      'Create custom categories that match your life. Understand exactly where every dollar lands.',
+  },
+];
+
+export function FeaturesSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section id="features" ref={ref} className="bg-white px-6 py-28">
+      <div className="mx-auto max-w-6xl">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="mb-16 text-center"
+        >
+          <span className="mb-4 inline-block rounded-full bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.45_0.15_162.48)]">
+            Everything you need
+          </span>
+          <h2 className="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Built for people, not accountants
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-gray-500">
+            No jargon. No complexity. Just the tools that actually help you stop
+            leaking money and start building a cushion.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature, i) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 24 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.5, delay: 0.1 + i * 0.08 }}
+              whileHover={{ y: -4 }}
+              className="group relative overflow-hidden rounded-2xl border border-gray-100 bg-white p-6 shadow-sm transition-shadow duration-300 hover:shadow-lg"
+            >
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                style={{
+                  background:
+                    'radial-gradient(ellipse 80% 80% at 50% 120%, oklch(0.696 0.17 162.48 / 5%) 0%, transparent 70%)',
+                }}
+              />
+              <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-[oklch(0.696_0.17_162.48/10%)] transition-colors duration-200 group-hover:bg-[oklch(0.696_0.17_162.48/18%)]">
+                <feature.icon className="h-5 w-5 text-[oklch(0.45_0.15_162.48)]" />
+              </div>
+              <h3 className="mb-2 font-semibold text-gray-900">{feature.title}</h3>
+              <p className="text-sm leading-relaxed text-gray-500">
+                {feature.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/FooterSection.tsx
+++ b/apps/web/src/components/landing/FooterSection.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { Wallet } from 'lucide-react';
+
+const links = [
+  { label: 'Features', href: '#features' },
+  { label: 'How it works', href: '#showcase' },
+  { label: 'Testimonials', href: '#testimonials' },
+  { label: 'FAQ', href: '#faq' },
+  { label: 'Sign in', href: '/login' },
+  { label: 'Register', href: '/register' },
+];
+
+export function FooterSection() {
+  return (
+    <footer className="border-t border-white/5 bg-[oklch(0.06_0_0)] px-6 py-12">
+      <div className="mx-auto max-w-6xl">
+        <div className="flex flex-col items-center gap-8 sm:flex-row sm:justify-between">
+          <Link href="/" className="flex items-center gap-2 group">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[oklch(0.696_0.17_162.48)] transition-transform duration-200 group-hover:scale-110">
+              <Wallet className="h-4 w-4 text-black" />
+            </div>
+            <span className="text-sm font-semibold text-white">My Pocket</span>
+          </Link>
+
+          <nav className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+            {links.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                className="text-xs text-white/40 transition-colors duration-200 hover:text-white/80"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+
+        <div className="mt-10 border-t border-white/5 pt-8 text-center">
+          <p className="text-xs text-white/20">
+            © {new Date().getFullYear()} My Pocket. Free forever.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/landing/FreeSection.tsx
+++ b/apps/web/src/components/landing/FreeSection.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { CheckCircle2 } from 'lucide-react';
+
+const included = [
+  'Unlimited transactions',
+  'Unlimited accounts',
+  'All budget categories',
+  'Recurring transaction tracker',
+  'Visual charts & insights',
+  'Dashboard overview',
+  'Income & expense tracking',
+  'No ads. Ever.',
+];
+
+export function FreeSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section
+      ref={ref}
+      className="relative overflow-hidden bg-[oklch(0.06_0_0)] px-6 py-28"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 60% at 50% 50%, oklch(0.696 0.17 162.48 / 10%) 0%, transparent 70%)',
+        }}
+      />
+      <div className="relative mx-auto max-w-2xl text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+        >
+          <span className="mb-4 inline-block rounded-full border border-[oklch(0.696_0.17_162.48/30%)] bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.696_0.17_162.48)]">
+            Pricing
+          </span>
+          <h2 className="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+            Completely free.
+            <br />
+            No catch.
+          </h2>
+          <p className="mt-4 text-lg text-white/50">
+            My Pocket is free because financial clarity shouldn't cost extra. Everything
+            is included — no tiers, no upsells, no expiration.
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 32 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="relative mt-10 overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur-sm"
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-px"
+            style={{
+              background:
+                'linear-gradient(90deg, transparent, oklch(0.696 0.17 162.48 / 60%), transparent)',
+            }}
+          />
+          <div className="mb-6 flex flex-col items-center">
+            <span className="text-6xl font-bold text-white">$0</span>
+            <span className="mt-1 text-sm text-white/40">forever</span>
+          </div>
+
+          <div className="mb-8 grid grid-cols-2 gap-3 text-left">
+            {included.map((item, i) => (
+              <motion.div
+                key={item}
+                initial={{ opacity: 0, x: -8 }}
+                animate={inView ? { opacity: 1, x: 0 } : {}}
+                transition={{ duration: 0.3, delay: 0.4 + i * 0.05 }}
+                className="flex items-center gap-2"
+              >
+                <CheckCircle2 className="h-4 w-4 shrink-0 text-[oklch(0.696_0.17_162.48)]" />
+                <span className="text-sm text-white/70">{item}</span>
+              </motion.div>
+            ))}
+          </div>
+
+          <a
+            href="/register"
+            className="block w-full rounded-xl bg-[oklch(0.696_0.17_162.48)] py-3 text-center text-sm font-semibold text-black shadow-lg shadow-[oklch(0.696_0.17_162.48/25%)] transition-all duration-200 hover:brightness-110 hover:shadow-xl hover:shadow-[oklch(0.696_0.17_162.48/35%)]"
+          >
+            Create your free account
+          </a>
+          <p className="mt-3 text-xs text-white/30">
+            No credit card. No trial period. No expiration.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { ArrowRight, Sparkles } from 'lucide-react';
+
+const stats = [
+  { value: '10,000+', label: 'Users in control' },
+  { value: '$8.4M', label: 'Tracked monthly' },
+  { value: '94%', label: 'Reach their goals' },
+];
+
+export function HeroSection() {
+  return (
+    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-black px-6 pt-20 text-center">
+      {/* Ambient glow */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 80% 60% at 50% -10%, oklch(0.696 0.17 162.48 / 18%) 0%, transparent 70%)',
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute bottom-0 left-0 right-0 h-px"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent, oklch(0.696 0.17 162.48 / 30%), transparent)',
+        }}
+      />
+
+      {/* Grid overlay */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage:
+            'linear-gradient(oklch(1 0 0) 1px, transparent 1px), linear-gradient(90deg, oklch(1 0 0) 1px, transparent 1px)',
+          backgroundSize: '60px 60px',
+        }}
+      />
+
+      <div className="relative z-10 max-w-4xl">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-6 inline-flex items-center gap-2 rounded-full border border-[oklch(0.696_0.17_162.48/30%)] bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5"
+        >
+          <Sparkles className="h-3.5 w-3.5 text-[oklch(0.696_0.17_162.48)]" />
+          <span className="text-xs font-medium tracking-wide text-[oklch(0.696_0.17_162.48)]">
+            Free forever · No credit card required
+          </span>
+        </motion.div>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="mb-6 text-5xl font-bold leading-[1.1] tracking-tight text-white sm:text-6xl lg:text-7xl"
+        >
+          Take back control
+          <br />
+          <span
+            style={{
+              background:
+                'linear-gradient(135deg, oklch(0.696 0.17 162.48), oklch(0.8 0.15 180))',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              backgroundClip: 'text',
+            }}
+          >
+            of your money.
+          </span>
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="mx-auto mb-10 max-w-xl text-lg leading-relaxed text-white/50"
+        >
+          Track every transaction, set budgets that actually work, and watch your
+          financial picture become clear — in minutes, not months.
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.3 }}
+          className="flex flex-wrap items-center justify-center gap-4"
+        >
+          <Link
+            href="/register"
+            className="group inline-flex items-center gap-2 rounded-xl bg-[oklch(0.696_0.17_162.48)] px-6 py-3 text-sm font-semibold text-black shadow-lg shadow-[oklch(0.696_0.17_162.48/25%)] transition-all duration-200 hover:brightness-110 hover:shadow-xl hover:shadow-[oklch(0.696_0.17_162.48/35%)]"
+          >
+            Start for free
+            <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 backdrop-blur-sm transition-all duration-200 hover:border-white/20 hover:bg-white/10"
+          >
+            Sign in
+          </Link>
+        </motion.div>
+
+        {/* Stats */}
+        <motion.div
+          initial={{ opacity: 0, y: 32 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.5 }}
+          className="mt-20 grid grid-cols-3 gap-8"
+        >
+          {stats.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.6 + i * 0.1 }}
+              className="flex flex-col items-center"
+            >
+              <span
+                className="text-3xl font-bold sm:text-4xl"
+                style={{
+                  background:
+                    'linear-gradient(135deg, oklch(0.696 0.17 162.48), oklch(0.85 0.12 175))',
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                  backgroundClip: 'text',
+                }}
+              >
+                {stat.value}
+              </span>
+              <span className="mt-1 text-xs text-white/40">{stat.label}</span>
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/LandingNav.tsx
+++ b/apps/web/src/components/landing/LandingNav.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Wallet, Menu, X } from 'lucide-react';
+
+const navLinks = [
+  { label: 'Features', href: '#features' },
+  { label: 'How it works', href: '#showcase' },
+  { label: 'Testimonials', href: '#testimonials' },
+  { label: 'FAQ', href: '#faq' },
+];
+
+export function LandingNav() {
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setScrolled(window.scrollY > 20);
+    window.addEventListener('scroll', handler, { passive: true });
+    return () => window.removeEventListener('scroll', handler);
+  }, []);
+
+  return (
+    <motion.header
+      initial={{ y: -80, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.5, ease: 'easeOut' }}
+      className={`fixed top-0 z-50 w-full transition-all duration-300 ${
+        scrolled
+          ? 'border-b border-white/10 bg-black/80 backdrop-blur-xl'
+          : 'bg-transparent'
+      }`}
+    >
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <Link href="/" className="flex items-center gap-2 group">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[oklch(0.696_0.17_162.48)] shadow-lg shadow-[oklch(0.696_0.17_162.48/30%)] transition-transform duration-200 group-hover:scale-110">
+            <Wallet className="h-4 w-4 text-black" />
+          </div>
+          <span className="text-sm font-semibold tracking-tight text-white">
+            My Pocket
+          </span>
+        </Link>
+
+        <nav className="hidden items-center gap-8 md:flex">
+          {navLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="text-sm text-white/60 transition-colors duration-200 hover:text-white"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="hidden items-center gap-3 md:flex">
+          <Link
+            href="/login"
+            className="text-sm text-white/60 transition-colors duration-200 hover:text-white"
+          >
+            Sign in
+          </Link>
+          <Link
+            href="/register"
+            className="rounded-lg bg-[oklch(0.696_0.17_162.48)] px-4 py-2 text-sm font-medium text-black transition-all duration-200 hover:brightness-110 hover:shadow-lg hover:shadow-[oklch(0.696_0.17_162.48/30%)]"
+          >
+            Get started free
+          </Link>
+        </div>
+
+        <button
+          className="text-white md:hidden"
+          onClick={() => setMobileOpen(!mobileOpen)}
+          aria-label="Toggle menu"
+        >
+          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {mobileOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden border-t border-white/10 bg-black/95 backdrop-blur-xl md:hidden"
+          >
+            <div className="flex flex-col gap-1 px-6 py-4">
+              {navLinks.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setMobileOpen(false)}
+                  className="py-2 text-sm text-white/70 transition-colors hover:text-white"
+                >
+                  {link.label}
+                </a>
+              ))}
+              <div className="mt-4 flex flex-col gap-2 border-t border-white/10 pt-4">
+                <Link
+                  href="/login"
+                  className="py-2 text-center text-sm text-white/60"
+                >
+                  Sign in
+                </Link>
+                <Link
+                  href="/register"
+                  className="rounded-lg bg-[oklch(0.696_0.17_162.48)] py-2 text-center text-sm font-medium text-black"
+                >
+                  Get started free
+                </Link>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.header>
+  );
+}

--- a/apps/web/src/components/landing/ProductShowcaseSection.tsx
+++ b/apps/web/src/components/landing/ProductShowcaseSection.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { TrendingDown, TrendingUp, DollarSign } from 'lucide-react';
+
+function MockDashboard() {
+  const bars = [65, 40, 80, 55, 90, 70, 45];
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'];
+
+  return (
+    <div className="relative w-full overflow-hidden rounded-2xl border border-white/10 bg-[oklch(0.10_0_0)] shadow-2xl shadow-black/60">
+      {/* Window chrome */}
+      <div className="flex items-center gap-2 border-b border-white/5 px-4 py-3">
+        <div className="h-2.5 w-2.5 rounded-full bg-red-500/70" />
+        <div className="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
+        <div className="h-2.5 w-2.5 rounded-full bg-green-500/70" />
+        <div className="mx-auto h-5 w-40 rounded-md bg-white/5 text-center text-[10px] leading-5 text-white/20">
+          mypocket.app/dashboard
+        </div>
+      </div>
+
+      <div className="p-5">
+        {/* Top stat cards */}
+        <div className="mb-5 grid grid-cols-3 gap-3">
+          {[
+            {
+              label: 'Balance',
+              value: '$3,842',
+              delta: '+$420',
+              up: true,
+              icon: DollarSign,
+            },
+            {
+              label: 'Income',
+              value: '$5,200',
+              delta: 'This month',
+              up: true,
+              icon: TrendingUp,
+            },
+            {
+              label: 'Expenses',
+              value: '$1,358',
+              delta: '-12% vs last',
+              up: false,
+              icon: TrendingDown,
+            },
+          ].map((card) => (
+            <div
+              key={card.label}
+              className="rounded-xl border border-white/5 bg-white/5 p-3"
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-[10px] text-white/40">{card.label}</span>
+                <card.icon className="h-3 w-3 text-white/20" />
+              </div>
+              <div className="text-base font-bold text-white">{card.value}</div>
+              <div
+                className={`mt-0.5 text-[10px] ${card.up ? 'text-[oklch(0.696_0.17_162.48)]' : 'text-red-400/70'}`}
+              >
+                {card.delta}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Chart */}
+        <div className="rounded-xl border border-white/5 bg-white/5 p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <span className="text-xs font-medium text-white/60">
+              Monthly spending
+            </span>
+            <span className="rounded-md bg-[oklch(0.696_0.17_162.48/15%)] px-2 py-0.5 text-[10px] text-[oklch(0.696_0.17_162.48)]">
+              2024
+            </span>
+          </div>
+          <div className="flex h-24 items-end gap-2">
+            {bars.map((h, i) => (
+              <motion.div
+                key={i}
+                initial={{ scaleY: 0 }}
+                animate={{ scaleY: 1 }}
+                transition={{ duration: 0.6, delay: 0.8 + i * 0.06, ease: 'easeOut' }}
+                style={{ transformOrigin: 'bottom', height: `${h}%` }}
+                className="flex-1 rounded-t-md"
+              >
+                <div
+                  className="h-full w-full rounded-t-md"
+                  style={{
+                    background:
+                      i === 4
+                        ? 'oklch(0.696 0.17 162.48)'
+                        : 'oklch(0.696 0.17 162.48 / 30%)',
+                  }}
+                />
+              </motion.div>
+            ))}
+          </div>
+          <div className="mt-2 flex gap-2">
+            {months.map((m) => (
+              <div key={m} className="flex-1 text-center text-[9px] text-white/20">
+                {m}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Recent transactions */}
+        <div className="mt-3 rounded-xl border border-white/5 bg-white/5 p-4">
+          <span className="mb-3 block text-xs font-medium text-white/60">
+            Recent transactions
+          </span>
+          <div className="space-y-2">
+            {[
+              { name: 'Grocery store', cat: 'Food', amount: '-$84.20', neg: true },
+              { name: 'Salary', cat: 'Income', amount: '+$3,200', neg: false },
+              { name: 'Netflix', cat: 'Subscriptions', amount: '-$15.99', neg: true },
+            ].map((tx) => (
+              <div key={tx.name} className="flex items-center justify-between">
+                <div>
+                  <div className="text-[11px] font-medium text-white/80">
+                    {tx.name}
+                  </div>
+                  <div className="text-[9px] text-white/30">{tx.cat}</div>
+                </div>
+                <span
+                  className={`text-[11px] font-semibold ${tx.neg ? 'text-red-400/80' : 'text-[oklch(0.696_0.17_162.48)]'}`}
+                >
+                  {tx.amount}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProductShowcaseSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section
+      id="showcase"
+      ref={ref}
+      className="relative overflow-hidden bg-[oklch(0.06_0_0)] px-6 py-28"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 70% 50% at 50% 100%, oklch(0.696 0.17 162.48 / 8%) 0%, transparent 70%)',
+        }}
+      />
+      <div className="relative mx-auto max-w-6xl">
+        <div className="grid items-center gap-16 lg:grid-cols-2">
+          <motion.div
+            initial={{ opacity: 0, x: -32 }}
+            animate={inView ? { opacity: 1, x: 0 } : {}}
+            transition={{ duration: 0.7 }}
+          >
+            <span className="mb-4 inline-block rounded-full bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.696_0.17_162.48)]">
+              How it works
+            </span>
+            <h2 className="mt-4 text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl">
+              Clarity in
+              <br />
+              under 5 minutes.
+            </h2>
+            <p className="mt-6 text-lg leading-relaxed text-white/50">
+              Add your accounts, log a few transactions, set a budget — and for the
+              first time, you'll see exactly where your money is going. Most users
+              find their first "leak" within the first session.
+            </p>
+
+            <ul className="mt-8 space-y-4">
+              {[
+                'Create an account — no payment info needed',
+                'Add your bank accounts and credit cards',
+                'Log income and expenses in seconds',
+                'Watch your dashboard paint the real picture',
+              ].map((step, i) => (
+                <motion.li
+                  key={step}
+                  initial={{ opacity: 0, x: -16 }}
+                  animate={inView ? { opacity: 1, x: 0 } : {}}
+                  transition={{ duration: 0.4, delay: 0.3 + i * 0.1 }}
+                  className="flex items-start gap-3"
+                >
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[oklch(0.696_0.17_162.48)] text-[10px] font-bold text-black">
+                    {i + 1}
+                  </span>
+                  <span className="text-sm leading-6 text-white/60">{step}</span>
+                </motion.li>
+              ))}
+            </ul>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, x: 32, y: 16 }}
+            animate={inView ? { opacity: 1, x: 0, y: 0 } : {}}
+            transition={{ duration: 0.7, delay: 0.2 }}
+            className="relative"
+          >
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -inset-8 rounded-3xl"
+              style={{
+                background:
+                  'radial-gradient(ellipse at center, oklch(0.696 0.17 162.48 / 12%) 0%, transparent 70%)',
+              }}
+            />
+            <MockDashboard />
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/SocialProofSection.tsx
+++ b/apps/web/src/components/landing/SocialProofSection.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useInView } from 'framer-motion';
+import { useRef } from 'react';
+import { Shield, Star, Users, TrendingDown } from 'lucide-react';
+
+const proofItems = [
+  { icon: Users, value: '10,000+', label: 'Active users' },
+  { icon: Star, value: '4.9 / 5', label: 'Average rating' },
+  { icon: TrendingDown, value: '68%', label: 'Cut overspending in month 1' },
+  { icon: Shield, value: '100%', label: 'Private & secure' },
+];
+
+export function SocialProofSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section
+      ref={ref}
+      className="border-y border-white/5 bg-[oklch(0.08_0_0)] px-6 py-16"
+    >
+      <div className="mx-auto max-w-5xl">
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={inView ? { opacity: 1 } : {}}
+          transition={{ duration: 0.5 }}
+          className="mb-10 text-center text-xs font-medium uppercase tracking-widest text-white/30"
+        >
+          Trusted by people reclaiming their finances
+        </motion.p>
+        <div className="grid grid-cols-2 gap-6 sm:grid-cols-4">
+          {proofItems.map((item, i) => (
+            <motion.div
+              key={item.label}
+              initial={{ opacity: 0, y: 16 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              className="flex flex-col items-center gap-2 text-center"
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[oklch(0.696_0.17_162.48/10%)]">
+                <item.icon className="h-5 w-5 text-[oklch(0.696_0.17_162.48)]" />
+              </div>
+              <span className="text-2xl font-bold text-white">{item.value}</span>
+              <span className="text-xs text-white/40">{item.label}</span>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/TestimonialsSection.tsx
+++ b/apps/web/src/components/landing/TestimonialsSection.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Star } from 'lucide-react';
+
+const testimonials = [
+  {
+    initials: 'MR',
+    name: 'Marcus R.',
+    role: 'Freelance designer',
+    quote:
+      "I was making good money but always broke by the 25th. Three weeks with My Pocket and I found $640/month I was wasting on subscriptions I'd forgotten about. Mind-blowing.",
+    stars: 5,
+    color: 'oklch(0.696 0.17 162.48)',
+  },
+  {
+    initials: 'SC',
+    name: 'Sofia C.',
+    role: 'Nurse, 2 kids',
+    quote:
+      "Budgeting apps always felt like homework. This one is different — I log a transaction in 10 seconds and the dashboard just... makes sense. First time I've kept a budget for more than a month.",
+    stars: 5,
+    color: 'oklch(0.6 0.18 250)',
+  },
+  {
+    initials: 'JT',
+    name: 'James T.',
+    role: 'Recent graduate',
+    quote:
+      "Started with $4,200 in credit card debt. Used the budget feature to find money every month. Paid it all off in 8 months. I genuinely didn't think that was possible for me.",
+    stars: 5,
+    color: 'oklch(0.7 0.16 50)',
+  },
+];
+
+function Stars({ count }: { count: number }) {
+  return (
+    <div className="flex gap-0.5">
+      {Array.from({ length: count }).map((_, i) => (
+        <Star
+          key={i}
+          className="h-3.5 w-3.5 fill-[oklch(0.696_0.17_162.48)] text-[oklch(0.696_0.17_162.48)]"
+        />
+      ))}
+    </div>
+  );
+}
+
+export function TestimonialsSection() {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-80px' });
+
+  return (
+    <section id="testimonials" ref={ref} className="bg-white px-6 py-28">
+      <div className="mx-auto max-w-6xl">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="mb-16 text-center"
+        >
+          <span className="mb-4 inline-block rounded-full bg-[oklch(0.696_0.17_162.48/10%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[oklch(0.45_0.15_162.48)]">
+            Real people, real results
+          </span>
+          <h2 className="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            They got their money back.
+            <br />
+            You can too.
+          </h2>
+        </motion.div>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          {testimonials.map((t, i) => (
+            <motion.div
+              key={t.name}
+              initial={{ opacity: 0, y: 32 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.6, delay: 0.1 + i * 0.12 }}
+              whileHover={{ y: -4 }}
+              className="group relative overflow-hidden rounded-2xl border border-gray-100 bg-white p-8 shadow-sm transition-shadow duration-300 hover:shadow-xl"
+            >
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                style={{
+                  background: `radial-gradient(ellipse 80% 60% at 50% 120%, ${t.color.replace(')', ' / 5%)')} 0%, transparent 70%)`,
+                }}
+              />
+              <Stars count={t.stars} />
+              <blockquote className="mt-4 text-sm leading-7 text-gray-600">
+                "{t.quote}"
+              </blockquote>
+              <div className="mt-6 flex items-center gap-3">
+                <div
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-xs font-bold text-black"
+                  style={{ background: t.color }}
+                >
+                  {t.initials}
+                </div>
+                <div>
+                  <div className="text-sm font-semibold text-gray-900">{t.name}</div>
+                  <div className="text-xs text-gray-400">{t.role}</div>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "@my-pocket/shared": "*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.42.2",
         "lucide-react": "^0.576.0",
         "next": "^15.2.0",
         "next-intl": "^4.8.3",
@@ -1178,6 +1179,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1216,6 +1218,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3648,6 +3651,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3808,6 +3812,7 @@
       "version": "11.1.14",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.14.tgz",
       "integrity": "sha512-IN/tlqd7Nl9gl6f0jsWEuOrQDaCI9vHzxv0fisHysfBQzfQIkqlv5A7w4Qge02BUQyczXT9HHPgHtWHCxhjRng==",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3853,6 +3858,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.14.tgz",
       "integrity": "sha512-7OXPPMoDr6z+5NkoQKu4hOhfjz/YYqM3bNilPqv1WVFWrzSmuNXxvhbX69YMmNmRYascPXiwESqf5jJdjKXEww==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3932,6 +3938,7 @@
       "version": "11.1.14",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.14.tgz",
       "integrity": "sha512-Fs+/j+mBSBSXErOQJ/YdUn/HqJGSJ4pGfiJyYOyz04l42uNVnqEakvu1kXLbxMabR6vd6/h9d6Bi4tso9p7o4Q==",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -4251,6 +4258,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7128,7 +7136,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7141,7 +7148,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7155,8 +7161,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -7329,8 +7334,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7605,6 +7609,7 @@
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7655,6 +7660,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7664,6 +7670,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7808,6 +7815,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -8612,6 +8620,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8666,6 +8675,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9123,6 +9133,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9335,6 +9346,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -9378,12 +9390,14 @@
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -10208,8 +10222,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -10522,6 +10535,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10581,6 +10595,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10842,6 +10857,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11279,6 +11295,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -11699,6 +11742,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
       "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12259,6 +12303,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -13021,6 +13066,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -13942,7 +13988,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14184,6 +14229,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -14999,6 +15059,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -15137,6 +15198,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -15166,6 +15228,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -15383,6 +15446,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15452,6 +15516,7 @@
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
       "devOptional": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -15699,6 +15764,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15715,6 +15781,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15725,13 +15792,15 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15931,7 +16000,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15945,7 +16015,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -16160,6 +16231,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -17447,6 +17519,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17845,6 +17918,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18086,6 +18160,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18445,6 +18520,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18780,7 +18856,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -18798,7 +18873,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -18811,7 +18885,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -18825,7 +18898,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -18834,15 +18906,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -18852,7 +18922,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -18865,7 +18934,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -19079,6 +19147,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -19166,6 +19235,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Replaces the placeholder home page with a full marketing landing page targeting users who want to regain control of their finances.

- Install framer-motion for scroll reveals, stagger, and microinteractions
- Add emerald brand accent CSS variables to the global theme
- Build 11 sections: sticky nav, hero (dark + ambient glow), social proof, features, product showcase (CSS mockup dashboard), benefits, testimonials, free pricing trust block, FAQ accordion, final CTA, footer
- Update page.test.tsx with 9 tests covering the new content